### PR TITLE
fix: cel budget

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-default: build
+default: build lint test
 
 .PHONY: lint
 lint:
@@ -9,5 +9,5 @@ test:
 	go test -v -cover ./...
 
 .PHONY: build
-build: lint test
+build:
 	@$(CURDIR)/script/code-gen.sh

--- a/hub/v1alpha1/api.go
+++ b/hub/v1alpha1/api.go
@@ -49,6 +49,7 @@ type API struct {
 // APISpec configures an API.
 type APISpec struct {
 	// PathPrefix is the path prefix under which the service will be exposed.
+	// +kubebuilder:validation:MaxLength=255
 	// +kubebuilder:validation:XValidation:message="must start with a '/'",rule="self.startsWith('/')"
 	// +kubebuilder:validation:XValidation:message="cannot contains '../'",rule="!self.matches(r\"\"\"(\\/\\.\\.\\/)|(\\/\\.\\.$)\"\"\")"
 	PathPrefix string `json:"pathPrefix"`
@@ -110,6 +111,7 @@ type OpenAPISpec struct {
 	// Path is the path on the Kubernetes Service for obtaining the specification.
 	// This Path must be queryable with a GET method and serve a YAML or JSON document.
 	// +optional
+	// +kubebuilder:validation:MaxLength=255
 	// +kubebuilder:validation:XValidation:message="must start with a '/'",rule="self.startsWith('/')"
 	// +kubebuilder:validation:XValidation:message="cannot contains '../'",rule="!self.matches(r\"\"\"(\\/\\.\\.\\/)|(\\/\\.\\.$)\"\"\")"
 	Path string `json:"path,omitempty"`

--- a/hub/v1alpha1/api_access.go
+++ b/hub/v1alpha1/api_access.go
@@ -62,6 +62,7 @@ type APIAccessSpec struct {
 	// Multiple APIAccesses can select the same APIs.
 	// When combined with APISelector, this set of APIs is appended to the matching APIs.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	// +kubebuilder:validation:XValidation:message="duplicated apis",rule="self.all(x, self.exists_one(y, x.name == y.name && (has(x.__namespace__) && x.__namespace__ != '' ? x.__namespace__ : 'default') == (has(y.__namespace__) && y.__namespace__ != '' ? y.__namespace__ : 'default')))"
 	APIs []APIReference `json:"apis,omitempty"`
 
@@ -76,6 +77,7 @@ type APIAccessSpec struct {
 	// Multiple APIAccesses can select the same APICollections.
 	// When combined with APICollectionSelector, this set of APICollections is appended to the matching APICollections.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	// +kubebuilder:validation:XValidation:message="duplicated collections",rule="self.all(x, self.exists_one(y, x.name == y.name))"
 	APICollections []APICollectionReference `json:"apiCollections,omitempty"`
 }
@@ -83,16 +85,19 @@ type APIAccessSpec struct {
 // APIReference contains information to identify an API to add to an APIAccess, an APICollection or an APIRateLimit.
 type APIReference struct {
 	// Name of the API.
+	// +kubebuilder:validation:MaxLength=253
 	Name string `json:"name"`
 
 	// Namespace of the API.
 	// +optional
+	// +kubebuilder:validation:MaxLength=63
 	Namespace string `json:"namespace,omitempty"`
 }
 
 // APICollectionReference contains information to identify an APICollection to add to APIAccess.
 type APICollectionReference struct {
 	// Name of the APICollection.
+	// +kubebuilder:validation:MaxLength=253
 	Name string `json:"name"`
 }
 

--- a/hub/v1alpha1/api_collection.go
+++ b/hub/v1alpha1/api_collection.go
@@ -45,6 +45,7 @@ type APICollection struct {
 type APICollectionSpec struct {
 	// PathPrefix is the path prefix under which all selected APIs will be exposed.
 	// +optional
+	// +kubebuilder:validation:MaxLength=255
 	// +kubebuilder:validation:XValidation:message="must start with a '/'",rule="self.startsWith('/')"
 	// +kubebuilder:validation:XValidation:message="cannot contains '../'",rule="!self.matches(r\"\"\"(\\/\\.\\.\\/)|(\\/\\.\\.$)\"\"\")"
 	PathPrefix string `json:"pathPrefix,omitempty"`
@@ -60,6 +61,7 @@ type APICollectionSpec struct {
 	// Multiple APICollections can select the same APIs.
 	// When combined with APISelector, this set of APIs is appended to the matching APIs.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	// +kubebuilder:validation:XValidation:message="duplicated apis",rule="self.all(x, self.exists_one(y, x.name == y.name && (has(x.__namespace__) && x.__namespace__ != '' ? x.__namespace__ : 'default') == (has(y.__namespace__) && y.__namespace__ != '' ? y.__namespace__ : 'default')))"
 	APIs []APIReference `json:"apis,omitempty"`
 }

--- a/hub/v1alpha1/api_gateway.go
+++ b/hub/v1alpha1/api_gateway.go
@@ -50,10 +50,15 @@ type APIGatewaySpec struct {
 
 	// CustomDomains are the custom domains under which the gateway will be exposed.
 	// +optional
-	// +kubebuilder:validation:XValidation:message="custom domain must be a valid domain name",rule="self.all(x, x.matches(r\"\"\"([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]\"\"\"))"
+	// +kubebuilder:validation:MaxItems=20
 	// +kubebuilder:validation:XValidation:message="duplicate domains",rule="self.all(x, self.exists_one(y, y == x))"
-	CustomDomains []string `json:"customDomains,omitempty"`
+	CustomDomains []Domain `json:"customDomains,omitempty"`
 }
+
+// Domain is the domain name.
+// +kubebuilder:validation:MaxLength=253
+// +kubebuilder:validation:XValidation:message="custom domain must be a valid domain name",rule="self.matches(r\"\"\"([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]\"\"\")"
+type Domain string
 
 // APIGatewayStatus is the status of an APIGateway.
 type APIGatewayStatus struct {

--- a/hub/v1alpha1/api_portal.go
+++ b/hub/v1alpha1/api_portal.go
@@ -56,33 +56,13 @@ type APIPortalSpec struct {
 
 	// CustomDomains are the custom domains under which the portal will be exposed.
 	// +optional
-	// +kubebuilder:validation:XValidation:message="custom domain must be a valid domain name",rule="self.all(x, x.matches(r\"\"\"([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]\"\"\"))"
+	// +kubebuilder:validation:MaxItems=20
 	// +kubebuilder:validation:XValidation:message="duplicate domains",rule="self.all(x, self.exists_one(y, y == x))"
-	CustomDomains []string `json:"customDomains,omitempty"`
+	CustomDomains []Domain `json:"customDomains,omitempty"`
 
 	// UI holds the UI customization options.
 	// +optional
 	UI *UISpec `json:"ui,omitempty"`
-}
-
-// APIPortalStatus is the status of an APIPortal.
-type APIPortalStatus struct {
-	Version  string      `json:"version,omitempty"`
-	SyncedAt metav1.Time `json:"syncedAt,omitempty"`
-
-	// URLs are the URLs for accessing the APIPortal WebUI.
-	URLs string `json:"urls"`
-
-	// HubDomain is the hub generated domain of the APIPortal WebUI.
-	// +optional
-	HubDomain string `json:"hubDomain"`
-
-	// CustomDomains are the custom domains for accessing the exposed APIPortal WebUI.
-	// +optional
-	CustomDomains []string `json:"customDomains,omitempty"`
-
-	// Hash is a hash representing the APIPortal.
-	Hash string `json:"hash,omitempty"`
 }
 
 // UISpec configures the UI customization.
@@ -122,6 +102,26 @@ type UIServiceBackendPort struct {
 	// This is a mutually exclusive setting with "Path".
 	// +optional
 	Number int32 `json:"number"`
+}
+
+// APIPortalStatus is the status of an APIPortal.
+type APIPortalStatus struct {
+	Version  string      `json:"version,omitempty"`
+	SyncedAt metav1.Time `json:"syncedAt,omitempty"`
+
+	// URLs are the URLs for accessing the APIPortal WebUI.
+	URLs string `json:"urls"`
+
+	// HubDomain is the hub generated domain of the APIPortal WebUI.
+	// +optional
+	HubDomain string `json:"hubDomain"`
+
+	// CustomDomains are the custom domains for accessing the exposed APIPortal WebUI.
+	// +optional
+	CustomDomains []string `json:"customDomains,omitempty"`
+
+	// Hash is a hash representing the APIPortal.
+	Hash string `json:"hash,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/hub/v1alpha1/api_rate_limit.go
+++ b/hub/v1alpha1/api_rate_limit.go
@@ -88,6 +88,7 @@ type APIRateLimitSpec struct {
 	// Multiple APIRateLimits can select the same APIs.
 	// When combined with APISelector, this set of APIs is appended to the matching APIs.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	// +kubebuilder:validation:XValidation:message="duplicated apis",rule="self.all(x, self.exists_one(y, x.name == y.name && (has(x.__namespace__) && x.__namespace__ != '' ? x.__namespace__ : 'default') == (has(y.__namespace__) && y.__namespace__ != '' ? y.__namespace__ : 'default')))"
 	APIs []APIReference `json:"apis,omitempty"`
 }

--- a/hub/v1alpha1/api_version.go
+++ b/hub/v1alpha1/api_version.go
@@ -55,6 +55,7 @@ type APIVersionSpec struct {
 	// Release is the version number of the API.
 	// This value must follow the SemVer format: https://semver.org/
 	// +optional
+	// +kubebuilder:validation:MaxLength=100
 	// +kubebuilder:validation:XValidation:message="must be a valid semver version",rule="self.matches(r\"\"\"^v?(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$\"\"\")"
 	Release string `json:"release,omitempty"`
 
@@ -64,6 +65,7 @@ type APIVersionSpec struct {
 
 	// Routes defines the different ways of accessing this APIVersion.
 	// +optional
+	// +kubebuilder:validation:MaxItems=10
 	Routes []Route `json:"routes,omitempty"`
 
 	// Service defines the backend handling the incoming traffic.
@@ -91,6 +93,7 @@ type Route struct {
 	// PathPrefix defines the path prefix to be routed to this APIVersion.
 	// This PathPrefix is appended to the PathPrefix of the APICollection and API.
 	// +optional
+	// +kubebuilder:validation:MaxLength=255
 	// +kubebuilder:validation:XValidation:message="must start with a '/'",rule="self.startsWith('/')"
 	// +kubebuilder:validation:XValidation:message="cannot contains '../'",rule="!self.matches(r\"\"\"(\\/\\.\\.\\/)|(\\/\\.\\.$)\"\"\")"
 	PathPrefix string `json:"pathPrefix,omitempty"`

--- a/hub/v1alpha1/crd/hub.traefik.io_apiaccesses.yaml
+++ b/hub/v1alpha1/crd/hub.traefik.io_apiaccesses.yaml
@@ -99,10 +99,12 @@ spec:
                   properties:
                     name:
                       description: Name of the APICollection.
+                      maxLength: 253
                       type: string
                   required:
                   - name
                   type: object
+                maxItems: 100
                 type: array
                 x-kubernetes-validations:
                 - message: duplicated collections
@@ -166,13 +168,16 @@ spec:
                   properties:
                     name:
                       description: Name of the API.
+                      maxLength: 253
                       type: string
                     namespace:
                       description: Namespace of the API.
+                      maxLength: 63
                       type: string
                   required:
                   - name
                   type: object
+                maxItems: 100
                 type: array
                 x-kubernetes-validations:
                 - message: duplicated apis

--- a/hub/v1alpha1/crd/hub.traefik.io_apicollections.yaml
+++ b/hub/v1alpha1/crd/hub.traefik.io_apicollections.yaml
@@ -100,13 +100,16 @@ spec:
                   properties:
                     name:
                       description: Name of the API.
+                      maxLength: 253
                       type: string
                     namespace:
                       description: Namespace of the API.
+                      maxLength: 63
                       type: string
                   required:
                   - name
                   type: object
+                maxItems: 100
                 type: array
                 x-kubernetes-validations:
                 - message: duplicated apis
@@ -117,6 +120,7 @@ spec:
               pathPrefix:
                 description: PathPrefix is the path prefix under which all selected
                   APIs will be exposed.
+                maxLength: 255
                 type: string
                 x-kubernetes-validations:
                 - message: must start with a '/'

--- a/hub/v1alpha1/crd/hub.traefik.io_apigateways.yaml
+++ b/hub/v1alpha1/crd/hub.traefik.io_apigateways.yaml
@@ -48,11 +48,15 @@ spec:
                 description: CustomDomains are the custom domains under which the
                   gateway will be exposed.
                 items:
+                  description: Domain is the domain name.
+                  maxLength: 253
                   type: string
+                  x-kubernetes-validations:
+                  - message: custom domain must be a valid domain name
+                    rule: self.matches(r"""([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]""")
+                maxItems: 20
                 type: array
                 x-kubernetes-validations:
-                - message: custom domain must be a valid domain name
-                  rule: self.all(x, x.matches(r"""([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]"""))
                 - message: duplicate domains
                   rule: self.all(x, self.exists_one(y, y == x))
             type: object

--- a/hub/v1alpha1/crd/hub.traefik.io_apiportals.yaml
+++ b/hub/v1alpha1/crd/hub.traefik.io_apiportals.yaml
@@ -46,11 +46,15 @@ spec:
                 description: CustomDomains are the custom domains under which the
                   portal will be exposed.
                 items:
+                  description: Domain is the domain name.
+                  maxLength: 253
                   type: string
+                  x-kubernetes-validations:
+                  - message: custom domain must be a valid domain name
+                    rule: self.matches(r"""([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]""")
+                maxItems: 20
                 type: array
                 x-kubernetes-validations:
-                - message: custom domain must be a valid domain name
-                  rule: self.all(x, x.matches(r"""([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]"""))
                 - message: duplicate domains
                   rule: self.all(x, self.exists_one(y, y == x))
               description:

--- a/hub/v1alpha1/crd/hub.traefik.io_apiratelimits.yaml
+++ b/hub/v1alpha1/crd/hub.traefik.io_apiratelimits.yaml
@@ -98,13 +98,16 @@ spec:
                   properties:
                     name:
                       description: Name of the API.
+                      maxLength: 253
                       type: string
                     namespace:
                       description: Namespace of the API.
+                      maxLength: 63
                       type: string
                   required:
                   - name
                   type: object
+                maxItems: 100
                 type: array
                 x-kubernetes-validations:
                 - message: duplicated apis

--- a/hub/v1alpha1/crd/hub.traefik.io_apis.yaml
+++ b/hub/v1alpha1/crd/hub.traefik.io_apis.yaml
@@ -128,6 +128,7 @@ spec:
               pathPrefix:
                 description: PathPrefix is the path prefix under which the service
                   will be exposed.
+                maxLength: 255
                 type: string
                 x-kubernetes-validations:
                 - message: must start with a '/'
@@ -149,6 +150,7 @@ spec:
                         description: Path is the path on the Kubernetes Service for
                           obtaining the specification. This Path must be queryable
                           with a GET method and serve a YAML or JSON document.
+                        maxLength: 255
                         type: string
                         x-kubernetes-validations:
                         - message: must start with a '/'

--- a/hub/v1alpha1/crd/hub.traefik.io_apiversions.yaml
+++ b/hub/v1alpha1/crd/hub.traefik.io_apiversions.yaml
@@ -131,6 +131,7 @@ spec:
               release:
                 description: 'Release is the version number of the API. This value
                   must follow the SemVer format: https://semver.org/'
+                maxLength: 100
                 type: string
                 x-kubernetes-validations:
                 - message: must be a valid semver version
@@ -150,6 +151,7 @@ spec:
                       description: PathPrefix defines the path prefix to be routed
                         to this APIVersion. This PathPrefix is appended to the PathPrefix
                         of the APICollection and API.
+                      maxLength: 255
                       type: string
                       x-kubernetes-validations:
                       - message: must start with a '/'
@@ -163,6 +165,7 @@ spec:
                         must be present in the request to be routed on this APIVersion.
                       type: object
                   type: object
+                maxItems: 10
                 type: array
               service:
                 description: Service defines the backend handling the incoming traffic.
@@ -179,6 +182,7 @@ spec:
                         description: Path is the path on the Kubernetes Service for
                           obtaining the specification. This Path must be queryable
                           with a GET method and serve a YAML or JSON document.
+                        maxLength: 255
                         type: string
                         x-kubernetes-validations:
                         - message: must start with a '/'

--- a/hub/v1alpha1/zz_generated.deepcopy.go
+++ b/hub/v1alpha1/zz_generated.deepcopy.go
@@ -365,7 +365,7 @@ func (in *APIGatewaySpec) DeepCopyInto(out *APIGatewaySpec) {
 	}
 	if in.CustomDomains != nil {
 		in, out := &in.CustomDomains, &out.CustomDomains
-		*out = make([]string, len(*in))
+		*out = make([]Domain, len(*in))
 		copy(*out, *in)
 	}
 	return
@@ -502,7 +502,7 @@ func (in *APIPortalSpec) DeepCopyInto(out *APIPortalSpec) {
 	*out = *in
 	if in.CustomDomains != nil {
 		in, out := &in.CustomDomains, &out.CustomDomains
-		*out = make([]string, len(*in))
+		*out = make([]Domain, len(*in))
 		copy(*out, *in)
 	}
 	if in.UI != nil {

--- a/pkg/validation/v1alpha1/gateway_test.go
+++ b/pkg/validation/v1alpha1/gateway_test.go
@@ -87,7 +87,7 @@ spec:
     - my-access
   customDomains:
     - ""`),
-			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.customDomains", BadValue: "array", Detail: "custom domain must be a valid domain name"}},
+			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.customDomains[0]", BadValue: "string", Detail: "custom domain must be a valid domain name"}},
 		},
 		{
 			desc: "invalid custom domain",
@@ -101,7 +101,7 @@ spec:
     - my-access
   customDomains:
     - example..com`),
-			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.customDomains", BadValue: "array", Detail: "custom domain must be a valid domain name"}},
+			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.customDomains[0]", BadValue: "string", Detail: "custom domain must be a valid domain name"}},
 		},
 		{
 			desc: "duplicate custom domains",

--- a/pkg/validation/v1alpha1/portal_test.go
+++ b/pkg/validation/v1alpha1/portal_test.go
@@ -103,7 +103,7 @@ spec:
   apiGateway: my-gateway
   customDomains:
     - ""`),
-			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.customDomains", BadValue: "array", Detail: "custom domain must be a valid domain name"}},
+			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.customDomains[0]", BadValue: "string", Detail: "custom domain must be a valid domain name"}},
 		},
 		{
 			desc: "invalid custom domain",
@@ -116,7 +116,7 @@ spec:
   apiGateway: my-gateway
   customDomains:
     - example..com`),
-			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.customDomains", BadValue: "array", Detail: "custom domain must be a valid domain name"}},
+			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.customDomains[0]", BadValue: "string", Detail: "custom domain must be a valid domain name"}},
 		},
 		{
 			desc: "duplicated custom domain",


### PR DESCRIPTION
This PR adds limits on some strings and list so the CEL cost estimator doesn't complain about budget overflow. 

The cost estimator impact negatively all rules applied on lists or strings of unbounded size, it assumes the worse case. 
Therefore, to prevent this behavior, we've introduced limits that shouldn't impact the user experience:
- Added various limits on strings
  - Referenced `name` limited to 253
  - Referenced `namespace` limited to 63
  - Paths limited to 200 characters
  - `customDomains` limited to 253 characters 
- Added limits on lists:
  - `apis` and `collections` are now limited to 200 (in APIAccess, APICollection and APIRateLimit). The reasoning being that if you need more than this you are probably not doing it right and you should instead use labels. There's still the escape hatch of creating a new resource if they really want to.
  - `customDomains` are limited to 20. 

If at some point customer complains about these limits it's still possible to increased them a little bit. But we can't reduce the limits afterward. 

For the record here were the errors we got when applying the CRDs:

```
CustomResourceDefinition.apiextensions.k8s.io "apiaccesses.hub.traefik.io" is invalid: [
    spec.validation.openAPIV3Schema.properties[spec].properties[apiCollections].x-kubernetes-validations[0].rule: Forbidden: estimated rule cost exceeds budget by factor of more than 100x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared), 
    spec.validation.openAPIV3Schema.properties[spec].properties[apis].x-kubernetes-validations[0].rule: Forbidden: estimated rule cost exceeds budget by factor of more than 100x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared), 
    spec.validation.openAPIV3Schema.properties[spec].properties[apis].x-kubernetes-validations[0].rule: Forbidden: contributed to estimated rule cost total exceeding cost limit for entire OpenAPIv3 schema, 
    spec.validation.openAPIV3Schema.properties[spec].properties[apiCollections].x-kubernetes-validations[0].rule: Forbidden: contributed to estimated rule cost total exceeding cost limit for entire OpenAPIv3 schema, 
    spec.validation.openAPIV3Schema: Forbidden: x-kubernetes-validations estimated rule cost total for entire OpenAPIv3 schema exceeds budget by factor of more than 100x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared)
]

CustomResourceDefinition.apiextensions.k8s.io "apicollections.hub.traefik.io" is invalid: [ 
    spec.validation.openAPIV3Schema.properties[spec].properties[apis].x-kubernetes-validations[0].rule: Forbidden: estimated rule cost exceeds budget by factor of more than 100x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared), 
    spec.validation.openAPIV3Schema.properties[spec].properties[apis].x-kubernetes-validations[0].rule: Forbidden: contributed to estimated rule cost total exceeding cost limit for entire OpenAPIv3 schema, 
    spec.validation.openAPIV3Schema.properties[spec].properties[pathPrefix].x-kubernetes-validations[1].rule: Forbidden: contributed to estimated rule cost total exceeding cost limit for entire OpenAPIv3 schema, 
    spec.validation.openAPIV3Schema: Forbidden: x-kubernetes-validations estimated rule cost total for entire OpenAPIv3 schema exceeds budget by factor of more than 100x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared)
]

CustomResourceDefinition.apiextensions.k8s.io "apigateways.hub.traefik.io" is invalid: [
    spec.validation.openAPIV3Schema.properties[spec].properties[customDomains].x-kubernetes-validations[0].rule: Forbidden: estimated rule cost exceeds budget by factor of more than 100x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared), 
    spec.validation.openAPIV3Schema.properties[spec].properties[customDomains].x-kubernetes-validations[1].rule: Forbidden: estimated rule cost exceeds budget by factor of more than 100x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared), 
    spec.validation.openAPIV3Schema.properties[spec].properties[customDomains].x-kubernetes-validations[1].rule: Forbidden: contributed to estimated rule cost total exceeding cost limit for entire OpenAPIv3 schema, 
    spec.validation.openAPIV3Schema.properties[spec].properties[customDomains].x-kubernetes-validations[0].rule: Forbidden: contributed to estimated rule cost total exceeding cost limit for entire OpenAPIv3 schema, 
    spec.validation.openAPIV3Schema: Forbidden: x-kubernetes-validations estimated rule cost total for entire OpenAPIv3 schema exceeds budget by factor of more than 100x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared)
]

CustomResourceDefinition.apiextensions.k8s.io "apiportals.hub.traefik.io" is invalid: [
    spec.validation.openAPIV3Schema.properties[spec].properties[customDomains].x-kubernetes-validations[0].rule: Forbidden: estimated rule cost exceeds budget by factor of more than 100x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared), 
    spec.validation.openAPIV3Schema.properties[spec].properties[customDomains].x-kubernetes-validations[1].rule: Forbidden: estimated rule cost exceeds budget by factor of more than 100x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared), 
    spec.validation.openAPIV3Schema.properties[spec].properties[customDomains].x-kubernetes-validations[1].rule: Forbidden: contributed to estimated rule cost total exceeding cost limit for entire OpenAPIv3 schema, 
    spec.validation.openAPIV3Schema.properties[spec].properties[customDomains].x-kubernetes-validations[0].rule: Forbidden: contributed to estimated rule cost total exceeding cost limit for entire OpenAPIv3 schema, 
    spec.validation.openAPIV3Schema: Forbidden: x-kubernetes-validations estimated rule cost total for entire OpenAPIv3 schema exceeds budget by factor of more than 100x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared)
]

CustomResourceDefinition.apiextensions.k8s.io "apiratelimits.hub.traefik.io" is invalid: [
    spec.validation.openAPIV3Schema.properties[spec].properties[apis].x-kubernetes-validations[0].rule: Forbidden: estimated rule cost exceeds budget by factor of more than 100x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared), 
    spec.validation.openAPIV3Schema.properties[spec].properties[apis].x-kubernetes-validations[0].rule: Forbidden: contributed to estimated rule cost total exceeding cost limit for entire OpenAPIv3 schema, 
    spec.validation.openAPIV3Schema: Forbidden: x-kubernetes-validations estimated rule cost total for entire OpenAPIv3 schema exceeds budget by factor of more than 100x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared)
]

CustomResourceDefinition.apiextensions.k8s.io "apiversions.hub.traefik.io" is invalid: [
    spec.validation.openAPIV3Schema.properties[spec].properties[release].x-kubernetes-validations[0].rule: Forbidden: estimated rule cost exceeds budget by factor of 1.447036x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared), 
    spec.validation.openAPIV3Schema.properties[spec].properties[routes].items.properties[pathPrefix].x-kubernetes-validations[1].rule: Forbidden: estimated rule cost exceeds budget by factor of more than 100x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared), 
    spec.validation.openAPIV3Schema.properties[spec].properties[routes].items.properties[pathPrefix].x-kubernetes-validations[1].rule: Forbidden: contributed to estimated rule cost total exceeding cost limit for entire OpenAPIv3 schema, 
    spec.validation.openAPIV3Schema.properties[spec].properties[release].x-kubernetes-validations[0].rule: Forbidden: contributed to estimated rule cost total exceeding cost limit for entire OpenAPIv3 schema, 
    spec.validation.openAPIV3Schema.properties[spec].properties[routes].items.properties[pathPrefix].x-kubernetes-validations[0].rule: Forbidden: contributed to estimated rule cost total exceeding cost limit for entire OpenAPIv3 schema, 
    spec.validation.openAPIV3Schema.properties[spec].properties[service].properties[openApiSpec].properties[path].x-kubernetes-validations[1].rule: Forbidden: contributed to estimated rule cost total exceeding cost limit for entire OpenAPIv3 schema, 
    spec.validation.openAPIV3Schema: Forbidden: x-kubernetes-validations estimated rule cost total for entire OpenAPIv3 schema exceeds budget by factor of more than 100x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared)
]
```

Tested on k8s v1.25.15 and 1.28.3