### PR TITLE
fix: relax the need for OAS for APIs and portals

### DIFF
--- a/hub/v1alpha1/api.go
+++ b/hub/v1alpha1/api.go
@@ -82,8 +82,9 @@ type APIService struct {
 	Port APIServiceBackendPort `json:"port"`
 
 	// OpenAPISpec defines where to obtain the OpenAPI specification of the Service.
+	// +optional
 	// +kubebuilder:validation:XValidation:message="path or url must be defined",rule="has(self.path) || has(self.url)"
-	OpenAPISpec OpenAPISpec `json:"openApiSpec"`
+	OpenAPISpec *OpenAPISpec `json:"openApiSpec,omitempty"`
 }
 
 // APIServiceBackendPort references a port on a Kubernetes Service.

--- a/hub/v1alpha1/crd/hub.traefik.io_apis.yaml
+++ b/hub/v1alpha1/crd/hub.traefik.io_apis.yaml
@@ -205,7 +205,6 @@ spec:
                     type: object
                 required:
                 - name
-                - openApiSpec
                 - port
                 type: object
             required:

--- a/hub/v1alpha1/crd/hub.traefik.io_apiversions.yaml
+++ b/hub/v1alpha1/crd/hub.traefik.io_apiversions.yaml
@@ -237,7 +237,6 @@ spec:
                     type: object
                 required:
                 - name
-                - openApiSpec
                 - port
                 type: object
               stripPathPrefix:

--- a/hub/v1alpha1/zz_generated.deepcopy.go
+++ b/hub/v1alpha1/zz_generated.deepcopy.go
@@ -679,7 +679,11 @@ func (in *APIReference) DeepCopy() *APIReference {
 func (in *APIService) DeepCopyInto(out *APIService) {
 	*out = *in
 	out.Port = in.Port
-	in.OpenAPISpec.DeepCopyInto(&out.OpenAPISpec)
+	if in.OpenAPISpec != nil {
+		in, out := &in.OpenAPISpec, &out.OpenAPISpec
+		*out = new(OpenAPISpec)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/validation/v1alpha1/api_test.go
+++ b/pkg/validation/v1alpha1/api_test.go
@@ -241,7 +241,7 @@ spec:
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec", BadValue: "object", Detail: "currentVersion or service must be defined"}},
 		},
 		{
-			desc: "service name, port and openApiSpec are required",
+			desc: "service name and port are required",
 			manifest: []byte(`
 apiVersion: hub.traefik.io/v1alpha1
 kind: API
@@ -253,7 +253,6 @@ spec:
   service: {}`),
 			wantErrs: field.ErrorList{
 				{Type: field.ErrorTypeRequired, Field: "spec.service.name", BadValue: ""},
-				{Type: field.ErrorTypeRequired, Field: "spec.service.openApiSpec", BadValue: ""},
 				{Type: field.ErrorTypeRequired, Field: "spec.service.port", BadValue: ""},
 			},
 		},

--- a/pkg/validation/v1alpha1/version_test.go
+++ b/pkg/validation/v1alpha1/version_test.go
@@ -267,7 +267,7 @@ spec:
       path: /openapi.json`),
 		},
 		{
-			desc: "service name, port and openApiSpec are required",
+			desc: "service name and port are required",
 			manifest: []byte(`
 apiVersion: hub.traefik.io/v1alpha1
 kind: APIVersion
@@ -280,7 +280,6 @@ spec:
       path: /openapi.json`),
 			wantErrs: field.ErrorList{
 				{Type: field.ErrorTypeRequired, Field: "spec.service.name", BadValue: ""},
-				{Type: field.ErrorTypeRequired, Field: "spec.service.openApiSpec", BadValue: ""},
 				{Type: field.ErrorTypeRequired, Field: "spec.service.port", BadValue: ""},
 			},
 		},


### PR DESCRIPTION
### Description

This PR is a follow-up of https://github.com/traefik/traefik-hub/pull/119 (as per @sdelicata [comment](https://github.com/traefik/traefik-hub/pull/119#pullrequestreview-1740165838)), and propagates accordingly the CRD update.
