### PR TITLE
fix: validation rule cost exceeds budget

### DIFF
--- a/hub/v1alpha1/api.go
+++ b/hub/v1alpha1/api.go
@@ -143,7 +143,7 @@ type OperationSet struct {
 
 // OperationMatcher selects the operations that will be part of the OperationSet.
 // +kubebuilder:validation:MinProperties=1
-// +kubebuilder:validation:XValidation:message="path, pathPrefix and pathRegex are mutually exclusive",rule="[has(self.path), has(self.pathPrefix), has(self.pathRegex)].map(x, x ? 1 : 0).sum() <= 1"
+// +kubebuilder:validation:XValidation:message="path, pathPrefix and pathRegex are mutually exclusive",rule="(!has(self.path) && !has(self.pathPrefix) && !has(self.pathRegex)) || (has(self.path) && !has(self.pathPrefix) && !has(self.pathRegex)) || (!has(self.path) && has(self.pathPrefix) && !has(self.pathRegex)) || (!has(self.path) && !has(self.pathPrefix) && has(self.pathRegex))"
 type OperationMatcher struct {
 	// Path defines the exact path of the spec operations to select.
 	// +optional

--- a/hub/v1alpha1/crd/hub.traefik.io_apis.yaml
+++ b/hub/v1alpha1/crd/hub.traefik.io_apis.yaml
@@ -196,8 +196,12 @@ spec:
                                 x-kubernetes-validations:
                                 - message: path, pathPrefix and pathRegex are mutually
                                     exclusive
-                                  rule: '[has(self.path), has(self.pathPrefix), has(self.pathRegex)].map(x,
-                                    x ? 1 : 0).sum() <= 1'
+                                  rule: (!has(self.path) && !has(self.pathPrefix)
+                                    && !has(self.pathRegex)) || (has(self.path) &&
+                                    !has(self.pathPrefix) && !has(self.pathRegex))
+                                    || (!has(self.path) && has(self.pathPrefix) &&
+                                    !has(self.pathRegex)) || (!has(self.path) && !has(self.pathPrefix)
+                                    && has(self.pathRegex))
                               maxItems: 100
                               minItems: 1
                               type: array

--- a/hub/v1alpha1/crd/hub.traefik.io_apiversions.yaml
+++ b/hub/v1alpha1/crd/hub.traefik.io_apiversions.yaml
@@ -228,8 +228,12 @@ spec:
                                 x-kubernetes-validations:
                                 - message: path, pathPrefix and pathRegex are mutually
                                     exclusive
-                                  rule: '[has(self.path), has(self.pathPrefix), has(self.pathRegex)].map(x,
-                                    x ? 1 : 0).sum() <= 1'
+                                  rule: (!has(self.path) && !has(self.pathPrefix)
+                                    && !has(self.pathRegex)) || (has(self.path) &&
+                                    !has(self.pathPrefix) && !has(self.pathRegex))
+                                    || (!has(self.path) && has(self.pathPrefix) &&
+                                    !has(self.pathRegex)) || (!has(self.path) && !has(self.pathPrefix)
+                                    && has(self.pathRegex))
                               maxItems: 100
                               minItems: 1
                               type: array


### PR DESCRIPTION
### Description

This PR fixes the operation matcher CEL validation rule whose cost exceeds the authorized budget.
This prevented `API` and `APIVersion` CRDs from being applied to a cluster.