### PR TITLE
fix: rename CABundle attribute to CA in HTTP client config

### DIFF
--- a/pkg/apis/hub/v1alpha1/access_control_policy.go
+++ b/pkg/apis/hub/v1alpha1/access_control_policy.go
@@ -203,8 +203,8 @@ type HTTPClientConfig struct {
 
 // HTTPClientConfigTLS configures TLS for HTTP clients.
 type HTTPClientConfigTLS struct {
-	// CABundle sets the CA bundle used to sign the Authorization Server certificate.
-	CABundle string `json:"caBundle,omitempty"`
+	// CA sets the CA bundle used to sign the Authorization Server certificate.
+	CA string `json:"ca,omitempty"`
 	// InsecureSkipVerify skips the Authorization Server certificate validation.
 	// For testing purposes only, do not use in production.
 	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty"`

--- a/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_accesscontrolpolicies.yaml
+++ b/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_accesscontrolpolicies.yaml
@@ -192,9 +192,9 @@ spec:
                         description: TLS configures TLS communication with the Authorization
                           Server.
                         properties:
-                          caBundle:
-                            description: CABundle sets the CA bundle used to sign
-                              the Authorization Server certificate.
+                          ca:
+                            description: CA sets the CA bundle used to sign the Authorization
+                              Server certificate.
                             type: string
                           insecureSkipVerify:
                             description: InsecureSkipVerify skips the Authorization


### PR DESCRIPTION
## Motivation

This pull request renames the CABundle attribute to CA in the HTTP client configuration to be consistent with the Client TLS configuration of Traefik.

This configuration is only used in the OAuth introspection ACP, which is not used in production, thus no migration is needed.

Co-authored-by: lbenguigui <lbenguigui@gmail.com>