### PR TITLE
remove auth attribute from OAuthintrospection

### DIFF
--- a/pkg/apis/hub/v1alpha1/access_control_policy.go
+++ b/pkg/apis/hub/v1alpha1/access_control_policy.go
@@ -167,9 +167,6 @@ type AccessControlOAuthIntroClientConfig struct {
 	// URL of the Authorization Server.
 	// +kubebuilder:validation:Required
 	URL string `json:"url"`
-	// Auth configures the required authentication to the Authorization Server.
-	// +kubebuilder:validation:Required
-	Auth AccessControlOAuthIntroClientConfigAuth `json:"auth"`
 	// Headers to set when sending requests to the Authorization Server.
 	Headers map[string]string `json:"headers,omitempty"`
 	// TokenTypeHint is a hint to pass to the Authorization Server.

--- a/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_accesscontrolpolicies.yaml
+++ b/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_accesscontrolpolicies.yaml
@@ -140,38 +140,6 @@ spec:
                     description: AccessControlOAuthIntroClientConfig configures the
                       OAuth 2.0 client for issuing token introspection requests.
                     properties:
-                      auth:
-                        description: Auth configures the required authentication to
-                          the Authorization Server.
-                        properties:
-                          kind:
-                            description: Kind sets the kind of authentication that
-                              can be used to authenticate requests. The content of
-                              the referenced depends on this kind.
-                            enum:
-                            - Basic
-                            - Bearer
-                            - Header
-                            - Query
-                            type: string
-                          secret:
-                            description: Secret is the reference to the Kubernetes
-                              secrets containing sensitive authentication data.
-                            properties:
-                              name:
-                                description: name is unique within a namespace to
-                                  reference a secret resource.
-                                type: string
-                              namespace:
-                                description: namespace defines the space within which
-                                  the secret name must be unique.
-                                type: string
-                            type: object
-                            x-kubernetes-map-type: atomic
-                        required:
-                        - kind
-                        - secret
-                        type: object
                       headers:
                         additionalProperties:
                           type: string
@@ -211,7 +179,6 @@ spec:
                         description: URL of the Authorization Server.
                         type: string
                     required:
-                    - auth
                     - url
                     type: object
                   forwardHeaders:

--- a/pkg/apis/hub/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/hub/v1alpha1/zz_generated.deepcopy.go
@@ -899,7 +899,6 @@ func (in *AccessControlOAuthIntro) DeepCopy() *AccessControlOAuthIntro {
 func (in *AccessControlOAuthIntroClientConfig) DeepCopyInto(out *AccessControlOAuthIntroClientConfig) {
 	*out = *in
 	in.HTTPClientConfig.DeepCopyInto(&out.HTTPClientConfig)
-	out.Auth = in.Auth
 	if in.Headers != nil {
 		in, out := &in.Headers, &out.Headers
 		*out = make(map[string]string, len(*in))


### PR DESCRIPTION
### Description

This PR removes `auth` attributes in OAuthIntrospection config.

related to https://github.com/traefik/hub-issues/issues/612