### PR TITLE
fix: check for unknown fields

### DIFF
--- a/pkg/validation/v1alpha1/access_test.go
+++ b/pkg/validation/v1alpha1/access_test.go
@@ -49,12 +49,12 @@ spec:
     - name: my-api
       namespace: my-ns
   apiSelector:
-    labelSelector:
+    matchLabels:
       key: value
   apiCollections:
     - name: my-api-collection
   apiCollectionSelector:
-    labelSelector:
+    matchLabels:
       key: value
   operationFilter:
     include:

--- a/pkg/validation/v1alpha1/api_test.go
+++ b/pkg/validation/v1alpha1/api_test.go
@@ -74,7 +74,7 @@ spec:
       path: /openapi.json
       operationSets:
         - name: my-operation-set
-          matchers: 
+          matchers:
             - path: /foo
               methods:
                 - GET
@@ -404,7 +404,7 @@ spec:
     openApiSpec:
       path: /foo
       operationSets:
-        - matchers: 
+        - matchers:
           - path: /foo`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeRequired, Field: "spec.service.openApiSpec.operationSets[0].name", BadValue: "", Detail: ""}},
 		},
@@ -467,7 +467,7 @@ spec:
       path: /foo
       operationSets:
         - name: my-operation-set
-          matchers: 
+          matchers:
             - {}`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.service.openApiSpec.operationSets[0].matchers[0]", BadValue: int64(0), Detail: "spec.service.openApiSpec.operationSets[0].matchers[0] in body should have at least 1 properties"}},
 		},
@@ -489,7 +489,7 @@ spec:
       path: /foo
       operationSets:
         - name: my-operation-set
-          matchers: 
+          matchers:
             - path: /foo
               pathPrefix: /foo`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.service.openApiSpec.operationSets[0].matchers[0]", BadValue: "object", Detail: "path, pathPrefix and pathRegex are mutually exclusive"}},
@@ -512,7 +512,7 @@ spec:
       path: /foo
       operationSets:
         - name: my-operation-set
-          matchers: 
+          matchers:
             - path: /foo
               pathRegex: /.*/foo`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.service.openApiSpec.operationSets[0].matchers[0]", BadValue: "object", Detail: "path, pathPrefix and pathRegex are mutually exclusive"}},
@@ -535,7 +535,7 @@ spec:
       path: /foo
       operationSets:
         - name: my-operation-set
-          matchers: 
+          matchers:
             - pathPrefix: /foo
               pathRegex: /.*/foo`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.service.openApiSpec.operationSets[0].matchers[0]", BadValue: "object", Detail: "path, pathPrefix and pathRegex are mutually exclusive"}},
@@ -558,7 +558,7 @@ spec:
       path: /foo
       operationSets:
         - name: my-operation-set
-          matchers: 
+          matchers:
             - path: /foo
               pathPrefix: /foo
               pathRegex: /.*/foo`),
@@ -581,8 +581,8 @@ spec:
     openApiSpec:
       path: /foo
       operationSets:
-        - name: my-operation-set 
-          matchers: 
+        - name: my-operation-set
+          matchers:
             - path: something`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.service.openApiSpec.operationSets[0].matchers[0].path", BadValue: "string", Detail: "must start with a '/'"}},
 		},
@@ -603,8 +603,8 @@ spec:
     openApiSpec:
       path: /foo
       operationSets:
-        - name: my-operation-set 
-          matchers: 
+        - name: my-operation-set
+          matchers:
             - path: /foo/../bar`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.service.openApiSpec.operationSets[0].matchers[0].path", BadValue: "string", Detail: "cannot contains '../'"}},
 		},
@@ -625,8 +625,8 @@ spec:
     openApiSpec:
       path: /foo
       operationSets:
-        - name: my-operation-set 
-          matchers: 
+        - name: my-operation-set
+          matchers:
             - path: /foo/..`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.service.openApiSpec.operationSets[0].matchers[0].path", BadValue: "string", Detail: "cannot contains '../'"}},
 		},
@@ -647,8 +647,8 @@ spec:
     openApiSpec:
       path: /foo
       operationSets:
-        - name: my-operation-set 
-          matchers: 
+        - name: my-operation-set
+          matchers:
             - path: /foo/..bar`),
 		},
 		{
@@ -668,8 +668,8 @@ spec:
     openApiSpec:
       path: /foo
       operationSets:
-        - name: my-operation-set 
-          matchers: 
+        - name: my-operation-set
+          matchers:
             - pathPrefix: something`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.service.openApiSpec.operationSets[0].matchers[0].pathPrefix", BadValue: "string", Detail: "must start with a '/'"}},
 		},
@@ -690,8 +690,8 @@ spec:
     openApiSpec:
       path: /foo
       operationSets:
-        - name: my-operation-set 
-          matchers: 
+        - name: my-operation-set
+          matchers:
             - pathPrefix: /foo/../bar`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.service.openApiSpec.operationSets[0].matchers[0].pathPrefix", BadValue: "string", Detail: "cannot contains '../'"}},
 		},
@@ -712,8 +712,8 @@ spec:
     openApiSpec:
       path: /foo
       operationSets:
-        - name: my-operation-set 
-          matchers: 
+        - name: my-operation-set
+          matchers:
             - pathPrefix: /foo/..`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.service.openApiSpec.operationSets[0].matchers[0].pathPrefix", BadValue: "string", Detail: "cannot contains '../'"}},
 		},
@@ -734,8 +734,8 @@ spec:
     openApiSpec:
       path: /foo
       operationSets:
-        - name: my-operation-set 
-          matchers: 
+        - name: my-operation-set
+          matchers:
             - pathPrefix: /foo/..bar`),
 		},
 		{
@@ -756,7 +756,7 @@ spec:
       path: /foo
       operationSets:
         - name: my-operation-set
-          matchers: 
+          matchers:
             - methods:
               - GET`),
 		},

--- a/pkg/validation/v1alpha1/collection_test.go
+++ b/pkg/validation/v1alpha1/collection_test.go
@@ -42,6 +42,7 @@ apiVersion: hub.traefik.io/v1alpha1
 kind: APICollection
 metadata:
   name: my-collection
+spec:
   pathPrefix: /collection
   apis:
     - name: my-api`),

--- a/pkg/validation/v1alpha1/validation_test.go
+++ b/pkg/validation/v1alpha1/validation_test.go
@@ -58,7 +58,7 @@ func checkValidationTestCases(t *testing.T, tests []validationTestCase) {
 			t.Parallel()
 
 			var object unstructured.Unstructured
-			_, decoderErr := decoder.Decode(test.manifest, &object)
+			decoderErr := decoder.Decode(test.manifest, &object)
 			require.NoError(t, decoderErr)
 
 			gotErrs := validator.Validate(&object)

--- a/pkg/validation/v1alpha1/version_test.go
+++ b/pkg/validation/v1alpha1/version_test.go
@@ -80,7 +80,7 @@ spec:
       path: /openapi.json
       operationSets:
         - name: my-operation-set
-          matchers: 
+          matchers:
             - path: /foo
               methods:
                 - GET
@@ -284,6 +284,7 @@ metadata:
 spec:
   apiName: my-api
   service:
+    openApiSpec:
       path: /openapi.json`),
 			wantErrs: field.ErrorList{
 				{Type: field.ErrorTypeRequired, Field: "spec.service.name", BadValue: ""},
@@ -413,7 +414,7 @@ spec:
     openApiSpec:
       path: /foo
       operationSets:
-        - matchers: 
+        - matchers:
           - path: /foo`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeRequired, Field: "spec.service.openApiSpec.operationSets[0].name", BadValue: "", Detail: ""}},
 		},
@@ -476,7 +477,7 @@ spec:
       path: /foo
       operationSets:
         - name: my-operation-set
-          matchers: 
+          matchers:
             - {}`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.service.openApiSpec.operationSets[0].matchers[0]", BadValue: int64(0), Detail: "spec.service.openApiSpec.operationSets[0].matchers[0] in body should have at least 1 properties"}},
 		},
@@ -498,7 +499,7 @@ spec:
       path: /foo
       operationSets:
         - name: my-operation-set
-          matchers: 
+          matchers:
             - path: /foo
               pathPrefix: /foo`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.service.openApiSpec.operationSets[0].matchers[0]", BadValue: "object", Detail: "path, pathPrefix and pathRegex are mutually exclusive"}},
@@ -521,7 +522,7 @@ spec:
       path: /foo
       operationSets:
         - name: my-operation-set
-          matchers: 
+          matchers:
             - path: /foo
               pathRegex: /.*/foo`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.service.openApiSpec.operationSets[0].matchers[0]", BadValue: "object", Detail: "path, pathPrefix and pathRegex are mutually exclusive"}},
@@ -544,7 +545,7 @@ spec:
       path: /foo
       operationSets:
         - name: my-operation-set
-          matchers: 
+          matchers:
             - pathPrefix: /foo
               pathRegex: /.*/foo`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.service.openApiSpec.operationSets[0].matchers[0]", BadValue: "object", Detail: "path, pathPrefix and pathRegex are mutually exclusive"}},
@@ -567,7 +568,7 @@ spec:
       path: /foo
       operationSets:
         - name: my-operation-set
-          matchers: 
+          matchers:
             - path: /foo
               pathPrefix: /foo
               pathRegex: /.*/foo`),
@@ -590,8 +591,8 @@ spec:
     openApiSpec:
       path: /foo
       operationSets:
-        - name: my-operation-set 
-          matchers: 
+        - name: my-operation-set
+          matchers:
             - path: something`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.service.openApiSpec.operationSets[0].matchers[0].path", BadValue: "string", Detail: "must start with a '/'"}},
 		},
@@ -612,8 +613,8 @@ spec:
     openApiSpec:
       path: /foo
       operationSets:
-        - name: my-operation-set 
-          matchers: 
+        - name: my-operation-set
+          matchers:
             - path: /foo/../bar`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.service.openApiSpec.operationSets[0].matchers[0].path", BadValue: "string", Detail: "cannot contains '../'"}},
 		},
@@ -634,8 +635,8 @@ spec:
     openApiSpec:
       path: /foo
       operationSets:
-        - name: my-operation-set 
-          matchers: 
+        - name: my-operation-set
+          matchers:
             - path: /foo/..`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.service.openApiSpec.operationSets[0].matchers[0].path", BadValue: "string", Detail: "cannot contains '../'"}},
 		},
@@ -656,8 +657,8 @@ spec:
     openApiSpec:
       path: /foo
       operationSets:
-        - name: my-operation-set 
-          matchers: 
+        - name: my-operation-set
+          matchers:
             - path: /foo/..bar`),
 		},
 		{
@@ -677,8 +678,8 @@ spec:
     openApiSpec:
       path: /foo
       operationSets:
-        - name: my-operation-set 
-          matchers: 
+        - name: my-operation-set
+          matchers:
             - pathPrefix: something`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.service.openApiSpec.operationSets[0].matchers[0].pathPrefix", BadValue: "string", Detail: "must start with a '/'"}},
 		},
@@ -699,8 +700,8 @@ spec:
     openApiSpec:
       path: /foo
       operationSets:
-        - name: my-operation-set 
-          matchers: 
+        - name: my-operation-set
+          matchers:
             - pathPrefix: /foo/../bar`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.service.openApiSpec.operationSets[0].matchers[0].pathPrefix", BadValue: "string", Detail: "cannot contains '../'"}},
 		},
@@ -721,8 +722,8 @@ spec:
     openApiSpec:
       path: /foo
       operationSets:
-        - name: my-operation-set 
-          matchers: 
+        - name: my-operation-set
+          matchers:
             - pathPrefix: /foo/..`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.service.openApiSpec.operationSets[0].matchers[0].pathPrefix", BadValue: "string", Detail: "cannot contains '../'"}},
 		},
@@ -743,8 +744,8 @@ spec:
     openApiSpec:
       path: /foo
       operationSets:
-        - name: my-operation-set 
-          matchers: 
+        - name: my-operation-set
+          matchers:
             - pathPrefix: /foo/..bar`),
 		},
 		{
@@ -765,7 +766,7 @@ spec:
       path: /foo
       operationSets:
         - name: my-operation-set
-          matchers: 
+          matchers:
             - methods:
               - GET`),
 		},


### PR DESCRIPTION
This PR fixes some tests that were using unknown fields/misplaced fields. To make sure this never happen again, the decoder has been updated to check for unknown fields.