### PR TITLE
remove namespace from apiReference

### DIFF
--- a/pkg/apis/hub/v1alpha1/api_access.go
+++ b/pkg/apis/hub/v1alpha1/api_access.go
@@ -61,7 +61,7 @@ type APIAccessSpec struct {
 	// When combined with APISelector, this set of APIs is appended to the matching APIs.
 	// +optional
 	// +kubebuilder:validation:MaxItems=100
-	// +kubebuilder:validation:XValidation:message="duplicated apis",rule="self.all(x, self.exists_one(y, x.name == y.name && (has(x.__namespace__) && x.__namespace__ != '' ? x.__namespace__ : 'default') == (has(y.__namespace__) && y.__namespace__ != '' ? y.__namespace__ : 'default')))"
+	// +kubebuilder:validation:XValidation:message="duplicated apis",rule="self.all(x, self.exists_one(y, x.name == y.name))"
 	APIs []APIReference `json:"apis,omitempty"`
 
 	// OperationFilter specifies the allowed operations on APIs and APIVersions.
@@ -76,11 +76,6 @@ type APIReference struct {
 	// Name of the API.
 	// +kubebuilder:validation:MaxLength=253
 	Name string `json:"name"`
-
-	// Namespace of the API.
-	// +optional
-	// +kubebuilder:validation:MaxLength=63
-	Namespace string `json:"namespace,omitempty"`
 }
 
 // OperationFilter specifies the allowed operations on APIs and APIVersions.

--- a/pkg/apis/hub/v1alpha1/api_rate_limit.go
+++ b/pkg/apis/hub/v1alpha1/api_rate_limit.go
@@ -87,7 +87,7 @@ type APIRateLimitSpec struct {
 	// When combined with APISelector, this set of APIs is appended to the matching APIs.
 	// +optional
 	// +kubebuilder:validation:MaxItems=100
-	// +kubebuilder:validation:XValidation:message="duplicated apis",rule="self.all(x, self.exists_one(y, x.name == y.name && (has(x.__namespace__) && x.__namespace__ != '' ? x.__namespace__ : 'default') == (has(y.__namespace__) && y.__namespace__ != '' ? y.__namespace__ : 'default')))"
+	// +kubebuilder:validation:XValidation:message="duplicated apis",rule="self.all(x, self.exists_one(y, x.name == y.name))"
 	APIs []APIReference `json:"apis,omitempty"`
 }
 

--- a/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiaccesses.yaml
+++ b/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiaccesses.yaml
@@ -94,10 +94,6 @@ spec:
                       description: Name of the API.
                       maxLength: 253
                       type: string
-                    namespace:
-                      description: Namespace of the API.
-                      maxLength: 63
-                      type: string
                   required:
                   - name
                   type: object
@@ -105,10 +101,7 @@ spec:
                 type: array
                 x-kubernetes-validations:
                 - message: duplicated apis
-                  rule: 'self.all(x, self.exists_one(y, x.name == y.name && (has(x.__namespace__)
-                    && x.__namespace__ != '''' ? x.__namespace__ : ''default'') ==
-                    (has(y.__namespace__) && y.__namespace__ != '''' ? y.__namespace__
-                    : ''default'')))'
+                  rule: self.all(x, self.exists_one(y, x.name == y.name))
               everyone:
                 description: Everyone indicates that all users will have access to
                   the selected APIs.

--- a/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiratelimits.yaml
+++ b/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiratelimits.yaml
@@ -94,10 +94,6 @@ spec:
                       description: Name of the API.
                       maxLength: 253
                       type: string
-                    namespace:
-                      description: Namespace of the API.
-                      maxLength: 63
-                      type: string
                   required:
                   - name
                   type: object
@@ -105,10 +101,7 @@ spec:
                 type: array
                 x-kubernetes-validations:
                 - message: duplicated apis
-                  rule: 'self.all(x, self.exists_one(y, x.name == y.name && (has(x.__namespace__)
-                    && x.__namespace__ != '''' ? x.__namespace__ : ''default'') ==
-                    (has(y.__namespace__) && y.__namespace__ != '''' ? y.__namespace__
-                    : ''default'')))'
+                  rule: self.all(x, self.exists_one(y, x.name == y.name))
               everyone:
                 description: Everyone indicates that all users will, by default, be
                   rate limited with this configuration. If an APIRateLimit explicitly

--- a/pkg/validation/v1alpha1/access_test.go
+++ b/pkg/validation/v1alpha1/access_test.go
@@ -58,7 +58,6 @@ spec:
     - my-group
   apis:
     - name: my-api
-      namespace: my-ns
   apiSelector:
     matchLabels:
       key: value
@@ -107,9 +106,7 @@ metadata:
 spec:
   apis:
     - name: my-api
-      namespace: my-ns
-    - name: my-api
-      namespace: my-ns`),
+    - name: my-api`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.apis", BadValue: "array", Detail: "duplicated apis"}},
 		},
 		{
@@ -123,38 +120,8 @@ metadata:
 spec:
   apis:
     - name: my-api
-      namespace: default
     - name: my-api`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.apis", BadValue: "array", Detail: "duplicated apis"}},
-		},
-		{
-			desc: "valid: apis with same name but different namespaces",
-			manifest: []byte(`
-apiVersion: hub.traefik.io/v1alpha1
-kind: APIAccess
-metadata:
-  name: my-access
-  namespace: default
-spec:
-  apis:
-    - name: my-api
-      namespace: my-ns-1
-    - name: my-api
-      namespace: my-ns-2`),
-		},
-		{
-			desc: "valid: apis with same name but only one with namespace",
-			manifest: []byte(`
-apiVersion: hub.traefik.io/v1alpha1
-kind: APIAccess
-metadata:
-  name: my-access
-  namespace: default
-spec:
-  apis:
-    - name: my-api
-      namespace: my-ns
-    - name: my-api`),
 		},
 		{
 			desc: "invalid API selector",

--- a/pkg/validation/v1alpha1/ratelimit_test.go
+++ b/pkg/validation/v1alpha1/ratelimit_test.go
@@ -62,8 +62,7 @@ spec:
   groups:
     - my-group
   apis:
-    - name: my-api
-      namespace: my-ns`),
+    - name: my-api`),
 		},
 		{
 			desc: "invalid resource name",
@@ -183,9 +182,7 @@ spec:
   limit: 1
   apis:
     - name: my-api
-      namespace: my-ns
-    - name: my-api
-      namespace: my-ns`),
+    - name: my-api`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.apis", BadValue: "array", Detail: "duplicated apis"}},
 		},
 		{
@@ -200,40 +197,8 @@ spec:
   limit: 1
   apis:
     - name: my-api
-      namespace: default
     - name: my-api`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.apis", BadValue: "array", Detail: "duplicated apis"}},
-		},
-		{
-			desc: "valid: apis with same name but different namespaces",
-			manifest: []byte(`
-apiVersion: hub.traefik.io/v1alpha1
-kind: APIRateLimit
-metadata:
-  name: my-ratelimit
-  namespace: default
-spec:
-  limit: 1
-  apis:
-    - name: my-api
-      namespace: my-ns-1
-    - name: my-api
-      namespace: my-ns-2`),
-		},
-		{
-			desc: "valid: apis with same name but only one with namespace",
-			manifest: []byte(`
-apiVersion: hub.traefik.io/v1alpha1
-kind: APIRateLimit
-metadata:
-  name: my-ratelimit
-  namespace: default
-spec:
-  limit: 1
-  apis:
-    - name: my-api
-      namespace: my-ns
-    - name: my-api`),
 		},
 		{
 			desc: "invalid API selector",


### PR DESCRIPTION
### Description

Since APIRatelimits & APIAccesses are namespaces, namespace in APIReference become useless.