### PR TITLE
fix: remove outdated printer columns

### DIFF
--- a/pkg/apis/hub/v1alpha1/api_portal.go
+++ b/pkg/apis/hub/v1alpha1/api_portal.go
@@ -25,7 +25,6 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // APIPortal defines a developer portal for accessing the documentation of APIs.
-// +kubebuilder:printcolumn:name="URLs",type=string,JSONPath=`.status.urls`
 type APIPortal struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/pkg/apis/hub/v1alpha1/api_version.go
+++ b/pkg/apis/hub/v1alpha1/api_version.go
@@ -25,7 +25,6 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // APIVersion defines a version of an API.
-// +kubebuilder:printcolumn:name="APIName",type=string,JSONPath=`.spec.apiName`
 // +kubebuilder:printcolumn:name="Title",type=string,JSONPath=`.spec.title`
 // +kubebuilder:printcolumn:name="Release",type=string,JSONPath=`.spec.release`
 type APIVersion struct {

--- a/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiportals.yaml
+++ b/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiportals.yaml
@@ -14,11 +14,7 @@ spec:
     singular: apiportal
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.urls
-      name: URLs
-      type: string
-    name: v1alpha1
+  - name: v1alpha1
     schema:
       openAPIV3Schema:
         description: APIPortal defines a developer portal for accessing the documentation
@@ -98,4 +94,3 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}

--- a/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiversions.yaml
+++ b/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiversions.yaml
@@ -15,9 +15,6 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.apiName
-      name: APIName
-      type: string
     - jsonPath: .spec.title
       name: Title
       type: string


### PR DESCRIPTION
### Description

This PR removes the `APIPortal.URLs` and `APIVersion.APIName` outdated printer columns.