### PR TITLE
feat: add ExternalIDClaim to the APIPortal OIDC status

### DIFF
--- a/pkg/apis/hub/v1alpha1/api_portal.go
+++ b/pkg/apis/hub/v1alpha1/api_portal.go
@@ -108,7 +108,7 @@ type OIDCConfigStatus struct {
 	// +optional
 	GroupsClaim string `json:"groupsClaim,omitempty"`
 
-	// CompanyClaim is the name of the JWT claim containing the user groups.
+	// CompanyClaim is the name of the JWT claim containing the user company.
 	// +optional
 	CompanyClaim string `json:"companyClaim,omitempty"`
 }

--- a/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiportals.yaml
+++ b/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiportals.yaml
@@ -83,7 +83,7 @@ spec:
                     type: string
                   companyClaim:
                     description: CompanyClaim is the name of the JWT claim containing
-                      the user groups.
+                      the user company.
                     type: string
                   emailClaim:
                     description: EmailClaim is the name of the JWT claim containing


### PR DESCRIPTION
### Description

This PR adds the `ExternalIDClaim` field to the APIPortal OIDC status.

Related to: https://github.com/traefik/hub-issues/issues/1042