### PR TITLE
fix: optional APIPlan on APIAccess

### DIFF
--- a/pkg/apis/hub/v1alpha1/api_access.go
+++ b/pkg/apis/hub/v1alpha1/api_access.go
@@ -79,7 +79,7 @@ type APIAccessSpec struct {
 
 	// APIPlan defines which APIPlan will be used.
 	// +optional
-	APIPlan APIPlanReference `json:"apiPlan,omitempty"`
+	APIPlan *APIPlanReference `json:"apiPlan,omitempty"`
 
 	// Weight specifies the evaluation order of the plan.
 	// +kubebuilder:validation:XValidation:message="must be a positive number",rule="self >= 0"

--- a/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiaccesses.yaml
+++ b/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiaccesses.yaml
@@ -41,7 +41,7 @@ spec:
             properties:
               apiBundles:
                 description: |-
-                  APIBundles defines a set of APIBundles that will be accessible to the configured audience.
+                  APIBundles defines a set of APIBundle that will be accessible to the configured audience.
                   Multiple APIAccesses can select the same APIBundles.
                 items:
                   description: APIBundleReference references an APIBundle.

--- a/pkg/apis/hub/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/hub/v1alpha1/zz_generated.deepcopy.go
@@ -147,7 +147,11 @@ func (in *APIAccessSpec) DeepCopyInto(out *APIAccessSpec) {
 		*out = new(OperationFilter)
 		(*in).DeepCopyInto(*out)
 	}
-	out.APIPlan = in.APIPlan
+	if in.APIPlan != nil {
+		in, out := &in.APIPlan, &out.APIPlan
+		*out = new(APIPlanReference)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
This PR fixes the APIAccess CRD to make APIPlan truly optional.
It was impossible to distinguish an empty reference from a reference with no name. Where in reality the reference is optional, not the name. It was also a problem since we would have serialized the reference as an empty struct.