### PR TITLE
feat: add APIPlans bucket support

### DIFF
--- a/pkg/apis/hub/v1alpha1/api_plan.go
+++ b/pkg/apis/hub/v1alpha1/api_plan.go
@@ -64,6 +64,16 @@ type APIPlanStatus struct {
 	Hash string `json:"hash,omitempty"`
 }
 
+// Bucket defines the scope of rate limit or quota.
+// +kubebuilder:validation:Enum=user;access
+type Bucket string
+
+// List of supported buckets.
+const (
+	BucketUser   Bucket = "user"
+	BucketAccess Bucket = "access"
+)
+
 type RateLimit struct {
 	// Limit is the maximum number of token in the bucket.
 	// +kubebuilder:validation:XValidation:message="must be a positive number",rule="self >= 0"
@@ -73,6 +83,10 @@ type RateLimit struct {
 	// +optional
 	// +kubebuilder:validation:XValidation:message="must be between 1s and 1h",rule="self >= duration('1s') && self <= duration('1h')"
 	Period *Period `json:"period,omitempty"`
+
+	// Bucket defines the scope of the rate limit.
+	// +optional
+	Bucket Bucket `json:"bucket,omitempty"`
 }
 
 type Quota struct {
@@ -84,6 +98,10 @@ type Quota struct {
 	// +optional
 	// +kubebuilder:validation:XValidation:message="must be between 1s and 9999h",rule="self >= duration('1s') && self <= duration('9999h')"
 	Period *Period `json:"period,omitempty"`
+
+	// Bucket defines the scope of the quota.
+	// +optional
+	Bucket Bucket `json:"bucket,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiplans.yaml
+++ b/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiplans.yaml
@@ -45,6 +45,12 @@ spec:
               quota:
                 description: Quota defines the quota policy.
                 properties:
+                  bucket:
+                    description: Bucket defines the scope of the quota.
+                    enum:
+                    - user
+                    - access
+                    type: string
                   limit:
                     description: Limit is the maximum number of token in the bucket.
                     type: integer
@@ -64,6 +70,12 @@ spec:
               rateLimit:
                 description: RateLimit defines the rate limit policy.
                 properties:
+                  bucket:
+                    description: Bucket defines the scope of the rate limit.
+                    enum:
+                    - user
+                    - access
+                    type: string
                   limit:
                     description: Limit is the maximum number of token in the bucket.
                     type: integer

--- a/pkg/validation/v1alpha1/plan_test.go
+++ b/pkg/validation/v1alpha1/plan_test.go
@@ -54,9 +54,11 @@ spec:
   rateLimit:
     limit: 1
     period: 2s
+    bucket: user
   quota:
     limit: 1
-    period: 2s`),
+    period: 2s
+    bucket: access`),
 		},
 		{
 			desc: "missing resource namespace",
@@ -216,6 +218,22 @@ spec:
     limit: 1
     period: 0s`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.rateLimit.period", BadValue: "string", Detail: "must be between 1s and 1h"}},
+		},
+		{
+			desc: "unsupported ratelimit bucket",
+			manifest: []byte(`
+apiVersion: hub.traefik.io/v1alpha1
+kind: APIPlan
+metadata:
+  name: my-plan
+  namespace: default
+spec:
+  title: my-plan
+  rateLimit:
+    limit: 1
+    period: 1s
+    bucket: something`),
+			wantErrs: field.ErrorList{{Type: field.ErrorTypeNotSupported, Field: "spec.rateLimit.bucket", BadValue: "something", Detail: "supported values: \"user\", \"access\""}},
 		},
 	}
 


### PR DESCRIPTION
This PR adds a new field `bucket` in the APIPlan resource. This new field controls the scope of the rate limit and quota.

Only 2 values are currently available:
- `user`: each user has it's own bucket on the requested API
- `access`: all users of the same bucket on the APIs defined within the APIAccess.

This field is optional. When not set the `access` bucket will be used.
