### PR TITLE
feat: oas path validation

### DIFF
--- a/pkg/apis/hub/v1alpha1/access_control_policy.go
+++ b/pkg/apis/hub/v1alpha1/access_control_policy.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/apis/hub/v1alpha1/ai_service.go
+++ b/pkg/apis/hub/v1alpha1/ai_service.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/apis/hub/v1alpha1/api.go
+++ b/pkg/apis/hub/v1alpha1/api.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/apis/hub/v1alpha1/api.go
+++ b/pkg/apis/hub/v1alpha1/api.go
@@ -86,6 +86,10 @@ type OpenAPISpec struct {
 	// +optional
 	// +kubebuilder:validation:MaxItems=100
 	OperationSets []OperationSet `json:"operationSets,omitempty"`
+
+	// ValidateRequestMethodAndPath validate that the path and method matches an operation defined in the OpenAPI specification.
+	// This option overrides the default behavior configured in the static configuration.
+	ValidateRequestMethodAndPath *bool `json:"validateRequestMethodAndPath,omitempty"`
 }
 
 type Override struct {

--- a/pkg/apis/hub/v1alpha1/api_access.go
+++ b/pkg/apis/hub/v1alpha1/api_access.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/apis/hub/v1alpha1/api_bundle.go
+++ b/pkg/apis/hub/v1alpha1/api_bundle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/apis/hub/v1alpha1/api_catalog_item.go
+++ b/pkg/apis/hub/v1alpha1/api_catalog_item.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/apis/hub/v1alpha1/api_plan.go
+++ b/pkg/apis/hub/v1alpha1/api_plan.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/apis/hub/v1alpha1/api_portal.go
+++ b/pkg/apis/hub/v1alpha1/api_portal.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/apis/hub/v1alpha1/api_rate_limit.go
+++ b/pkg/apis/hub/v1alpha1/api_rate_limit.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/apis/hub/v1alpha1/api_version.go
+++ b/pkg/apis/hub/v1alpha1/api_version.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/apis/hub/v1alpha1/crd/embed.go
+++ b/pkg/apis/hub/v1alpha1/crd/embed.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apis.yaml
+++ b/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apis.yaml
@@ -153,6 +153,11 @@ spec:
                     x-kubernetes-validations:
                     - message: must be a valid URL
                       rule: isURL(self)
+                  validateRequestMethodAndPath:
+                    description: |-
+                      ValidateRequestMethodAndPath validate that the path and method matches an operation defined in the OpenAPI specification.
+                      This option overrides the default behavior configured in the static configuration.
+                    type: boolean
                 type: object
                 x-kubernetes-validations:
                 - message: path or url must be defined

--- a/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiversions.yaml
+++ b/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiversions.yaml
@@ -157,6 +157,11 @@ spec:
                     x-kubernetes-validations:
                     - message: must be a valid URL
                       rule: isURL(self)
+                  validateRequestMethodAndPath:
+                    description: |-
+                      ValidateRequestMethodAndPath validate that the path and method matches an operation defined in the OpenAPI specification.
+                      This option overrides the default behavior configured in the static configuration.
+                    type: boolean
                 type: object
                 x-kubernetes-validations:
                 - message: path or url must be defined

--- a/pkg/apis/hub/v1alpha1/doc.go
+++ b/pkg/apis/hub/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/apis/hub/v1alpha1/managed_subscription.go
+++ b/pkg/apis/hub/v1alpha1/managed_subscription.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/apis/hub/v1alpha1/register.go
+++ b/pkg/apis/hub/v1alpha1/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/apis/hub/v1alpha1/types.go
+++ b/pkg/apis/hub/v1alpha1/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/apis/hub/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/hub/v1alpha1/zz_generated.deepcopy.go
@@ -4,7 +4,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published
@@ -1880,6 +1880,11 @@ func (in *OpenAPISpec) DeepCopyInto(out *OpenAPISpec) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.ValidateRequestMethodAndPath != nil {
+		in, out := &in.ValidateRequestMethodAndPath, &out.ValidateRequestMethodAndPath
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/fake/doc.go
+++ b/pkg/client/clientset/versioned/fake/doc.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/scheme/doc.go
+++ b/pkg/client/clientset/versioned/scheme/doc.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/accesscontrolpolicy.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/accesscontrolpolicy.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/aiservice.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/aiservice.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/api.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/api.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/apiaccess.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/apiaccess.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/apibundle.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/apibundle.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/apicatalogitem.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/apicatalogitem.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/apiplan.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/apiplan.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/apiportal.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/apiportal.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/apiratelimit.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/apiratelimit.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/apiversion.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/apiversion.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/doc.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/doc.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/doc.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/doc.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_accesscontrolpolicy.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_accesscontrolpolicy.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_aiservice.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_aiservice.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_api.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_api.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_apiaccess.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_apiaccess.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_apibundle.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_apibundle.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_apicatalogitem.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_apicatalogitem.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_apiplan.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_apiplan.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_apiportal.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_apiportal.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_apiratelimit.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_apiratelimit.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_apiversion.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_apiversion.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_hub_client.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_hub_client.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_managedsubscription.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/fake/fake_managedsubscription.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/generated_expansion.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/generated_expansion.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/hub_client.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/hub_client.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/clientset/versioned/typed/hub/v1alpha1/managedsubscription.go
+++ b/pkg/client/clientset/versioned/typed/hub/v1alpha1/managedsubscription.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/informers/externalversions/hub/interface.go
+++ b/pkg/client/informers/externalversions/hub/interface.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/informers/externalversions/hub/v1alpha1/accesscontrolpolicy.go
+++ b/pkg/client/informers/externalversions/hub/v1alpha1/accesscontrolpolicy.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/informers/externalversions/hub/v1alpha1/aiservice.go
+++ b/pkg/client/informers/externalversions/hub/v1alpha1/aiservice.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/informers/externalversions/hub/v1alpha1/api.go
+++ b/pkg/client/informers/externalversions/hub/v1alpha1/api.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/informers/externalversions/hub/v1alpha1/apiaccess.go
+++ b/pkg/client/informers/externalversions/hub/v1alpha1/apiaccess.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/informers/externalversions/hub/v1alpha1/apibundle.go
+++ b/pkg/client/informers/externalversions/hub/v1alpha1/apibundle.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/informers/externalversions/hub/v1alpha1/apicatalogitem.go
+++ b/pkg/client/informers/externalversions/hub/v1alpha1/apicatalogitem.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/informers/externalversions/hub/v1alpha1/apiplan.go
+++ b/pkg/client/informers/externalversions/hub/v1alpha1/apiplan.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/informers/externalversions/hub/v1alpha1/apiportal.go
+++ b/pkg/client/informers/externalversions/hub/v1alpha1/apiportal.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/informers/externalversions/hub/v1alpha1/apiratelimit.go
+++ b/pkg/client/informers/externalversions/hub/v1alpha1/apiratelimit.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/informers/externalversions/hub/v1alpha1/apiversion.go
+++ b/pkg/client/informers/externalversions/hub/v1alpha1/apiversion.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/informers/externalversions/hub/v1alpha1/interface.go
+++ b/pkg/client/informers/externalversions/hub/v1alpha1/interface.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/informers/externalversions/hub/v1alpha1/managedsubscription.go
+++ b/pkg/client/informers/externalversions/hub/v1alpha1/managedsubscription.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/listers/hub/v1alpha1/accesscontrolpolicy.go
+++ b/pkg/client/listers/hub/v1alpha1/accesscontrolpolicy.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/listers/hub/v1alpha1/aiservice.go
+++ b/pkg/client/listers/hub/v1alpha1/aiservice.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/listers/hub/v1alpha1/api.go
+++ b/pkg/client/listers/hub/v1alpha1/api.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/listers/hub/v1alpha1/apiaccess.go
+++ b/pkg/client/listers/hub/v1alpha1/apiaccess.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/listers/hub/v1alpha1/apibundle.go
+++ b/pkg/client/listers/hub/v1alpha1/apibundle.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/listers/hub/v1alpha1/apicatalogitem.go
+++ b/pkg/client/listers/hub/v1alpha1/apicatalogitem.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/listers/hub/v1alpha1/apiplan.go
+++ b/pkg/client/listers/hub/v1alpha1/apiplan.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/listers/hub/v1alpha1/apiportal.go
+++ b/pkg/client/listers/hub/v1alpha1/apiportal.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/listers/hub/v1alpha1/apiratelimit.go
+++ b/pkg/client/listers/hub/v1alpha1/apiratelimit.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/listers/hub/v1alpha1/apiversion.go
+++ b/pkg/client/listers/hub/v1alpha1/apiversion.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/listers/hub/v1alpha1/expansion_generated.go
+++ b/pkg/client/listers/hub/v1alpha1/expansion_generated.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/client/listers/hub/v1alpha1/managedsubscription.go
+++ b/pkg/client/listers/hub/v1alpha1/managedsubscription.go
@@ -1,7 +1,7 @@
 /*
 The GNU AFFERO GENERAL PUBLIC LICENSE
 
-Copyright (c) 2020-2024 Traefik Labs
+Copyright (c) 2020-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/crd/decoder.go
+++ b/pkg/crd/decoder.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/crd/loader.go
+++ b/pkg/crd/loader.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/validation/v1alpha1/access_test.go
+++ b/pkg/validation/v1alpha1/access_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/validation/v1alpha1/ai_service_test.go
+++ b/pkg/validation/v1alpha1/ai_service_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/validation/v1alpha1/api_test.go
+++ b/pkg/validation/v1alpha1/api_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published
@@ -47,6 +47,7 @@ metadata:
 spec:
   openApiSpec:
     path: /openapi.json
+    validateRequestMethodAndPath: true
     operationSets:
     - name: my-operation-set
       matchers:
@@ -112,6 +113,7 @@ spec:
   openApiSpec: {}`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.openApiSpec", BadValue: "object", Detail: "path or url must be defined"}},
 		},
+
 		{
 			desc: "openApiSpec url must be a valid URL",
 			manifest: []byte(`

--- a/pkg/validation/v1alpha1/bundle_test.go
+++ b/pkg/validation/v1alpha1/bundle_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published
@@ -59,7 +59,7 @@ kind: APIBundle
 metadata:
   name: my-bundle
   namespace: default
-spec: 
+spec:
   apis:
     - name: my-api
   apiSelector:

--- a/pkg/validation/v1alpha1/catalog_item_test.go
+++ b/pkg/validation/v1alpha1/catalog_item_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/validation/v1alpha1/managed_subscription_test.go
+++ b/pkg/validation/v1alpha1/managed_subscription_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/validation/v1alpha1/plan_test.go
+++ b/pkg/validation/v1alpha1/plan_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/validation/v1alpha1/portal_test.go
+++ b/pkg/validation/v1alpha1/portal_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/validation/v1alpha1/ratelimit_test.go
+++ b/pkg/validation/v1alpha1/ratelimit_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/validation/v1alpha1/validation_test.go
+++ b/pkg/validation/v1alpha1/validation_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/validation/v1alpha1/version_test.go
+++ b/pkg/validation/v1alpha1/version_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published
@@ -52,6 +52,7 @@ spec:
   title: My API Version 1
   openApiSpec:
     path: /openapi.json
+    validateRequestMethodAndPath: true
     operationSets:
       - name: my-operation-set
         matchers:
@@ -179,7 +180,7 @@ metadata:
   name: my-api-v1
   namespace: my-ns
 spec:
-  release: v1.0.0  
+  release: v1.0.0
   openApiSpec:
     path: /foo/../bar`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "spec.openApiSpec.path", BadValue: "string", Detail: "cannot contains '../'"}},

--- a/pkg/validation/validator.go
+++ b/pkg/validation/validator.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published

--- a/pkg/validation/validator_test.go
+++ b/pkg/validation/validator_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2022-2024 Traefik Labs
+Copyright (C) 2022-2025 Traefik Labs
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published


### PR DESCRIPTION
This PR updates the API and APIVersion CRDs to add a new `validateRequestMethodAndPath` option. This option controls whether or not calls to endpoints not defined in the specification are allowed to pass. This option overrides the behavior of the global static config option `--hub.apiManagement.openApi.validateRequestMethodAndPath`.

Please note that this PR also updates the copyright date that is on top of every file. 