### PR TITLE
fix: add missing omitempty for API title and description fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/traefik/hub-crds
 
 go 1.23.0
 
-toolchain go1.23.4
-
 require (
 	github.com/stretchr/testify v1.10.0
 	k8s.io/api v0.32.0

--- a/pkg/apis/hub/v1alpha1/api.go
+++ b/pkg/apis/hub/v1alpha1/api.go
@@ -44,11 +44,11 @@ type APISpec struct {
 	// Title is the human-readable name of the API that will be used on the portal.
 	// +optional
 	// +kubebuilder:validation:MaxLength=253
-	Title string `json:"title"`
+	Title string `json:"title,omitempty"`
 
 	// Description explains what the API does.
 	// +optional
-	Description string `json:"description"`
+	Description string `json:"description,omitempty"`
 
 	// OpenAPISpec defines the API contract as an OpenAPI specification.
 	// +optional

--- a/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apis.yaml
+++ b/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apis.yaml
@@ -43,7 +43,7 @@ spec:
             description: APISpec describes the API.
             properties:
               description:
-                description: Description is the API Description.
+                description: Description explains what the API does.
                 type: string
               openApiSpec:
                 description: OpenAPISpec defines the API contract as an OpenAPI specification.
@@ -166,7 +166,8 @@ spec:
                 - message: path or url must be defined
                   rule: has(self.path) || has(self.url)
               title:
-                description: Title is the API Title.
+                description: Title is the human-readable name of the API that will
+                  be used on the portal.
                 maxLength: 253
                 type: string
               versions:


### PR DESCRIPTION
### Description

This PR adds the missing `omitempy` tag into the API title and description fields.

It also updates the description of these fields in the CRD and removes the toolchain previously added to the go.mod file.