### PR TITLE
feat: add APIBundle title field

### DIFF
--- a/pkg/apis/hub/v1alpha1/api_bundle.go
+++ b/pkg/apis/hub/v1alpha1/api_bundle.go
@@ -40,6 +40,11 @@ type APIBundle struct {
 
 // APIBundleSpec configures an APIBundle.
 type APIBundleSpec struct {
+	// Title is the human-readable name of the APIBundle that will be used on the portal.
+	// +optional
+	// +kubebuilder:validation:MaxLength=253
+	Title string `json:"title,omitempty"`
+
 	// APISelector selects the APIs that will be accessible to the configured audience.
 	// Multiple APIBundles can select the same set of APIs.
 	// This field is optional and follows standard label selector semantics.

--- a/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apibundles.yaml
+++ b/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apibundles.yaml
@@ -109,6 +109,11 @@ spec:
                 x-kubernetes-validations:
                 - message: duplicated apis
                   rule: self.all(x, self.exists_one(y, x.name == y.name))
+              title:
+                description: Title is the human-readable name of the APIBundle that
+                  will be used on the portal.
+                maxLength: 253
+                type: string
             type: object
           status:
             description: The current status of this APIBundle.

--- a/pkg/validation/v1alpha1/bundle_test.go
+++ b/pkg/validation/v1alpha1/bundle_test.go
@@ -60,6 +60,7 @@ metadata:
   name: my-bundle
   namespace: default
 spec:
+  title: My API Bundle Title
   apis:
     - name: my-api
   apiSelector:
@@ -95,6 +96,18 @@ metadata:
   name: access-with-a-way-toooooooooooooooooooooooooooooooooooooo-long-name
   namespace: default`),
 			wantErrs: field.ErrorList{{Type: field.ErrorTypeInvalid, Field: "metadata.name", BadValue: "access-with-a-way-toooooooooooooooooooooooooooooooooooooo-long-name", Detail: "must be no more than 63 characters"}},
+		},
+		{
+			desc: "title is too long",
+			manifest: []byte(`
+apiVersion: hub.traefik.io/v1alpha1
+kind: APIBundle
+metadata:
+  name: my-bundle
+  namespace: default
+spec:
+  title: Way Toooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo Long Title`),
+			wantErrs: field.ErrorList{{Type: field.ErrorTypeTooLong, Field: "spec.title", BadValue: "<value omitted>", Detail: "may not be more than 253 bytes"}},
 		},
 		{
 			desc: "duplicated APIs",


### PR DESCRIPTION
### Description

This PR adds the `title` field on the `APIBundle` resource.

Fixes: https://github.com/traefik/hub-issues/issues/1729