### PR TITLE
fix: valid APIAuth OpenAPI specification

### DIFF
--- a/pkg/apis/hub/v1alpha1/api_auth.go
+++ b/pkg/apis/hub/v1alpha1/api_auth.go
@@ -55,6 +55,9 @@ type APIAuthSpec struct {
 }
 
 // APIKeyAuthSpec configures API key authentication.
+// +kubebuilder:pruning:PreserveUnknownFields
+// PreserveUnknownFields annotation is needed because this is an empty struct,
+// which would generate an invalid OpenAPI schema without explicit properties.
 type APIKeyAuthSpec struct{}
 
 // JWTAuthSpec configures JWT authentication.

--- a/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiauths.yaml
+++ b/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiauths.yaml
@@ -42,6 +42,7 @@ spec:
               apiKey:
                 description: APIKey configures API key authentication.
                 type: object
+                x-kubernetes-preserve-unknown-fields: true
               isDefault:
                 description: |-
                   IsDefault specifies if this APIAuth should be used as the default API authentication method for the namespace.


### PR DESCRIPTION
This PR fixes the APIAuth resource definition that resulted in an invalid OpenAPI spec due to the empty APIKeyAuthSpec struct.

The APIKeyAuthSpec struct was defined as an empty struct (type APIKeyAuthSpec struct{}), which generates an OpenAPI schema without any properties or validation rules. Different Kubernetes distributions have varying levels of strictness when validating such schemas:
  - k3d: More tolerant with incomplete object schemas
  - MicroK8s: Enforces stricter OpenAPI validation and rejects schemas for empty objects
  
The solution was to add the `+kubebuilder:pruning:PreserveUnknownFields` annotation to the APIKeyAuthSpec struct, which generates x-kubernetes-preserve-unknown-fields: true in the CRD manifest. It explicitly tells Kubernetes to accept this object type even without defined properties.