### PR TITLE
feat: Added clientConfig to APIPortalAuth and APIAuth

### DIFF
--- a/pkg/apis/hub/v1alpha1/access_control_policy.go
+++ b/pkg/apis/hub/v1alpha1/access_control_policy.go
@@ -176,21 +176,21 @@ type AccessControlOAuthIntroClientConfig struct {
 
 // HTTPClientConfig configures HTTP clients.
 type HTTPClientConfig struct {
-	// TLS configures TLS communication with the Authorization Server.
+	// TLS configures TLS for the HTTP client.
 	TLS *HTTPClientConfigTLS `json:"tls,omitempty"`
 	// TimeoutSeconds configures the maximum amount of seconds to wait before giving up on requests.
 	// +kubebuilder:default:=5
 	TimeoutSeconds int `json:"timeoutSeconds,omitempty"`
-	// MaxRetries defines the number of retries for introspection requests.
+	// MaxRetries defines the maximum number of retry attempts for failed requests.
 	// +kubebuilder:default:=3
 	MaxRetries int `json:"maxRetries,omitempty"`
 }
 
 // HTTPClientConfigTLS configures TLS for HTTP clients.
 type HTTPClientConfigTLS struct {
-	// CA sets the CA bundle used to sign the Authorization Server certificate.
+	// CA sets the CA bundle used to verify the server certificate.
 	CA string `json:"ca,omitempty"`
-	// InsecureSkipVerify skips the Authorization Server certificate validation.
+	// InsecureSkipVerify skips the server certificate validation.
 	// For testing purposes only, do not use in production.
 	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty"`
 }

--- a/pkg/apis/hub/v1alpha1/api_auth.go
+++ b/pkg/apis/hub/v1alpha1/api_auth.go
@@ -159,6 +159,10 @@ type JWTAuthSpec struct {
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=100
 	TrustedIssuers []TrustedIssuer `json:"trustedIssuers,omitempty"`
+
+	// ClientConfig configures the HTTP client used to fetch the JWKS from the JWKS URL or the trusted issuers.
+	// +optional
+	ClientConfig *HTTPClientConfig `json:"clientConfig,omitempty"`
 }
 
 // APIAuthStatus is the status of an APIAuth.

--- a/pkg/apis/hub/v1alpha1/api_portal_auth.go
+++ b/pkg/apis/hub/v1alpha1/api_portal_auth.go
@@ -73,6 +73,10 @@ type OIDCConfig struct {
 	// +kubebuilder:validation:MaxItems=6
 	// +kubebuilder:validation:items:Enum=groups;userId;firstname;lastname;email;company
 	SyncedAttributes []string `json:"syncedAttributes,omitempty"`
+
+	// ClientConfig configures the HTTP client used to communicate with the OIDC provider.
+	// +optional
+	ClientConfig *HTTPClientConfig `json:"clientConfig,omitempty"`
 }
 
 // Claims configures JWT claim mappings for user attributes.

--- a/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_accesscontrolpolicies.yaml
+++ b/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_accesscontrolpolicies.yaml
@@ -152,8 +152,8 @@ spec:
                         type: object
                       maxRetries:
                         default: 3
-                        description: MaxRetries defines the number of retries for
-                          introspection requests.
+                        description: MaxRetries defines the maximum number of retry
+                          attempts for failed requests.
                         type: integer
                       timeoutSeconds:
                         default: 5
@@ -161,16 +161,15 @@ spec:
                           of seconds to wait before giving up on requests.
                         type: integer
                       tls:
-                        description: TLS configures TLS communication with the Authorization
-                          Server.
+                        description: TLS configures TLS for the HTTP client.
                         properties:
                           ca:
-                            description: CA sets the CA bundle used to sign the Authorization
-                              Server certificate.
+                            description: CA sets the CA bundle used to verify the
+                              server certificate.
                             type: string
                           insecureSkipVerify:
                             description: |-
-                              InsecureSkipVerify skips the Authorization Server certificate validation.
+                              InsecureSkipVerify skips the server certificate validation.
                               For testing purposes only, do not use in production.
                             type: boolean
                         type: object

--- a/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiauths.yaml
+++ b/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiauths.yaml
@@ -81,6 +81,34 @@ spec:
                       AppIDClaim is the name of the claim holding the identifier of the application.
                       This field is sometimes named `client_id`.
                     type: string
+                  clientConfig:
+                    description: ClientConfig configures the HTTP client used to fetch
+                      the JWKS from the JWKS URL or the trusted issuers.
+                    properties:
+                      maxRetries:
+                        default: 3
+                        description: MaxRetries defines the maximum number of retry
+                          attempts for failed requests.
+                        type: integer
+                      timeoutSeconds:
+                        default: 5
+                        description: TimeoutSeconds configures the maximum amount
+                          of seconds to wait before giving up on requests.
+                        type: integer
+                      tls:
+                        description: TLS configures TLS for the HTTP client.
+                        properties:
+                          ca:
+                            description: CA sets the CA bundle used to verify the
+                              server certificate.
+                            type: string
+                          insecureSkipVerify:
+                            description: |-
+                              InsecureSkipVerify skips the server certificate validation.
+                              For testing purposes only, do not use in production.
+                            type: boolean
+                        type: object
+                    type: object
                   forwardHeaders:
                     additionalProperties:
                       type: string

--- a/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiportalauths.yaml
+++ b/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiportalauths.yaml
@@ -167,6 +167,34 @@ spec:
                     required:
                     - groups
                     type: object
+                  clientConfig:
+                    description: ClientConfig configures the HTTP client used to communicate
+                      with the OIDC provider.
+                    properties:
+                      maxRetries:
+                        default: 3
+                        description: MaxRetries defines the maximum number of retry
+                          attempts for failed requests.
+                        type: integer
+                      timeoutSeconds:
+                        default: 5
+                        description: TimeoutSeconds configures the maximum amount
+                          of seconds to wait before giving up on requests.
+                        type: integer
+                      tls:
+                        description: TLS configures TLS for the HTTP client.
+                        properties:
+                          ca:
+                            description: CA sets the CA bundle used to verify the
+                              server certificate.
+                            type: string
+                          insecureSkipVerify:
+                            description: |-
+                              InsecureSkipVerify skips the server certificate validation.
+                              For testing purposes only, do not use in production.
+                            type: boolean
+                        type: object
+                    type: object
                   issuerUrl:
                     description: IssuerURL is the OIDC provider issuer URL.
                     type: string

--- a/pkg/apis/hub/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/hub/v1alpha1/zz_generated.deepcopy.go
@@ -2178,6 +2178,11 @@ func (in *JWTAuthSpec) DeepCopyInto(out *JWTAuthSpec) {
 		*out = make([]TrustedIssuer, len(*in))
 		copy(*out, *in)
 	}
+	if in.ClientConfig != nil {
+		in, out := &in.ClientConfig, &out.ClientConfig
+		*out = new(HTTPClientConfig)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 
@@ -2559,6 +2564,11 @@ func (in *OIDCConfig) DeepCopyInto(out *OIDCConfig) {
 		in, out := &in.SyncedAttributes, &out.SyncedAttributes
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.ClientConfig != nil {
+		in, out := &in.ClientConfig, &out.ClientConfig
+		*out = new(HTTPClientConfig)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/validation/v1alpha1/api_auth_test.go
+++ b/pkg/validation/v1alpha1/api_auth_test.go
@@ -230,6 +230,54 @@ spec:
       - jwksUrl: "https://fallback.example.com/jwks.json"`),
 		},
 		{
+			desc: "valid: JWT with clientConfig",
+			manifest: []byte(`
+apiVersion: hub.traefik.io/v1alpha1
+kind: APIAuth
+metadata:
+  name: my-auth
+  namespace: default
+spec:
+  isDefault: true
+  jwt:
+    appIdClaim: "client_id"
+    jwksUrl: "https://example.com/.well-known/jwks.json"
+    clientConfig:
+      timeoutSeconds: 10
+      maxRetries: 5
+      tls:
+        ca: |
+          -----BEGIN CERTIFICATE-----
+          MIIBCzCBsqADAgECAhBaooOsws+BLdvtfqQ1ggx5MAoGCCqGSM49BAMCMBIxEDAO
+          BgNVBAoTB0V4YW1wbGUwHhcNMjQwMTAxMDAwMDAwWhcNMjUwMTAxMDAwMDAwWjAS
+          MRAwDgYDVQQKEwdFeGFtcGxlMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKNho
+          zEli5D+VsLgKJcgT0rp+MnYGJ4PjN8qgXfQx1F5JhtVBVnH8qWmza2XwJvVZAgUg
+          WijH8vDvBJU8su1w16MdMBswDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwCgYI
+          KoZIzj0EAwIDSAAwRQIgcu4/UZKPaUPCAB2jjqKbW8XqBp8fv1F8D5FO5hL1DqwC
+          IQDB3g0Lhx4QbM3Kw6bk0gvvVVLkb/TXe2Nvl4dH8gOCEw==
+          -----END CERTIFICATE-----
+        insecureSkipVerify: false`),
+		},
+		{
+			desc: "valid: JWT trustedIssuers with clientConfig",
+			manifest: []byte(`
+apiVersion: hub.traefik.io/v1alpha1
+kind: APIAuth
+metadata:
+  name: my-auth
+  namespace: default
+spec:
+  isDefault: true
+  jwt:
+    appIdClaim: "client_id"
+    trustedIssuers:
+      - jwksUrl: "https://tenant-a.example.com/jwks.json"
+        issuer: "https://tenant-a.example.com/"
+    clientConfig:
+      timeoutSeconds: 15
+      maxRetries: 2`),
+		},
+		{
 			desc: "valid: JWT with trusted issuers fallback only (no issuer specified)",
 			manifest: []byte(`
 apiVersion: hub.traefik.io/v1alpha1

--- a/pkg/validation/v1alpha1/api_portal_auth_test.go
+++ b/pkg/validation/v1alpha1/api_portal_auth_test.go
@@ -102,6 +102,36 @@ spec:
       - "company"`),
 		},
 		{
+			desc: "valid: OIDC with clientConfig",
+			manifest: []byte(`
+apiVersion: hub.traefik.io/v1alpha1
+kind: APIPortalAuth
+metadata:
+  name: my-auth
+  namespace: default
+spec:
+  oidc:
+    issuerUrl: "https://auth.example.com"
+    secretName: "oidc-secret"
+    claims:
+      groups: "groups"
+    clientConfig:
+      timeoutSeconds: 10
+      maxRetries: 5
+      tls:
+        ca: |
+          -----BEGIN CERTIFICATE-----
+          MIIBCzCBsqADAgECAhBaooOsws+BLdvtfqQ1ggx5MAoGCCqGSM49BAMCMBIxEDAO
+          BgNVBAoTB0V4YW1wbGUwHhcNMjQwMTAxMDAwMDAwWhcNMjUwMTAxMDAwMDAwWjAS
+          MRAwDgYDVQQKEwdFeGFtcGxlMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKNho
+          zEli5D+VsLgKJcgT0rp+MnYGJ4PjN8qgXfQx1F5JhtVBVnH8qWmza2XwJvVZAgUg
+          WijH8vDvBJU8su1w16MdMBswDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwCgYI
+          KoZIzj0EAwIDSAAwRQIgcu4/UZKPaUPCAB2jjqKbW8XqBp8fv1F8D5FO5hL1DqwC
+          IQDB3g0Lhx4QbM3Kw6bk0gvvVVLkb/TXe2Nvl4dH8gOCEw==
+          -----END CERTIFICATE-----
+        insecureSkipVerify: false`),
+		},
+		{
 			desc: "invalid resource name",
 			manifest: []byte(`
 apiVersion: hub.traefik.io/v1alpha1


### PR DESCRIPTION
### Description
Added following new configurations to APIPortalAuth and APIAuth:

**1. clientConfig.maxRetries**
 maximum number of retry attempts for failed requests.

**2. clientConfig.timeoutSeconds**
maximum amount of seconds to wait before giving up on requests.

**3. clientConfig.tls.ca**
CA bundle used to verify the server certificate.

**4. clientConfig.tls.insecureSkipVerify**
Skips the server certificate validation.
