### PR TITLE
ci: restrict lint-on-pr workflow permissions to read-only

### DIFF
--- a/.github/workflows/lint-on-pr.yaml
+++ b/.github/workflows/lint-on-pr.yaml
@@ -10,6 +10,9 @@ concurrency:
 env:
   # renovate: datasource=github-releases depName=golangci/golangci-lint
   golang_ci_lint_version: v2.7.2
+permissions:
+  contents: read
+
 jobs:
   go-tests:
     if: ${{ !github.event.pull_request.draft }}


### PR DESCRIPTION
Adds an explicit least-privilege `permissions:` block to `.github/workflows/lint-on-pr.yaml`. The job only reads the repository, so `contents: read` is sufficient; today the workflow inherits whatever the repository default grants, which is broader than it needs. This is one of the checks OpenSSF Scorecard flags under [Token-Permissions](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions).