### PR TITLE
feat: Add organizationId and organizationName OIDC claims

### DIFF
--- a/pkg/apis/hub/v1alpha1/api_portal_auth.go
+++ b/pkg/apis/hub/v1alpha1/api_portal_auth.go
@@ -103,6 +103,14 @@ type Claims struct {
 	// Company is the JWT claim for user company.
 	// +optional
 	Company string `json:"company,omitempty"`
+
+	// OrganizationID is the identifier of the organization the user belongs to.
+	// +optional
+	OrganizationID string `json:"organizationId,omitempty"`
+
+	// OrganizationName is the name of the organization the user belongs to.
+	// +optional
+	OrganizationName string `json:"organizationName,omitempty"`
 }
 
 // LDAPConnectionConfig holds LDAP connection configuration.

--- a/pkg/apis/hub/v1alpha1/api_portal_auth.go
+++ b/pkg/apis/hub/v1alpha1/api_portal_auth.go
@@ -104,11 +104,11 @@ type Claims struct {
 	// +optional
 	Company string `json:"company,omitempty"`
 
-	// OrganizationID is the identifier of the organization the user belongs to.
+	// OrganizationID is the JWT claim for the ID of the organization the user belongs to.
 	// +optional
 	OrganizationID string `json:"organizationId,omitempty"`
 
-	// OrganizationName is the name of the organization the user belongs to.
+	// OrganizationName is the JWT claim for the name of the organization the user belongs to.
 	// +optional
 	OrganizationName string `json:"organizationName,omitempty"`
 }

--- a/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiportalauths.yaml
+++ b/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiportalauths.yaml
@@ -162,12 +162,12 @@ spec:
                         description: Lastname is the JWT claim for user last name.
                         type: string
                       organizationId:
-                        description: OrganizationID is the identifier of the organization
-                          the user belongs to.
+                        description: OrganizationID is the JWT claim for the ID of
+                          the organization the user belongs to.
                         type: string
                       organizationName:
-                        description: OrganizationName is the name of the organization
-                          the user belongs to.
+                        description: OrganizationName is the JWT claim for the name
+                          of the organization the user belongs to.
                         type: string
                       userId:
                         description: UserID is the JWT claim for user ID mapping.

--- a/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiportalauths.yaml
+++ b/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_apiportalauths.yaml
@@ -161,6 +161,14 @@ spec:
                       lastname:
                         description: Lastname is the JWT claim for user last name.
                         type: string
+                      organizationId:
+                        description: OrganizationID is the identifier of the organization
+                          the user belongs to.
+                        type: string
+                      organizationName:
+                        description: OrganizationName is the name of the organization
+                          the user belongs to.
+                        type: string
                       userId:
                         description: UserID is the JWT claim for user ID mapping.
                         type: string

--- a/pkg/validation/v1alpha1/api_portal_auth_test.go
+++ b/pkg/validation/v1alpha1/api_portal_auth_test.go
@@ -96,10 +96,61 @@ spec:
       email: "email"
       groups: "groups"
       company: "organization"
+      organizationId: "org_id"
+      organizationName: "org_name"
     syncedAttributes:
       - "userId"
       - "firstname"
       - "company"`),
+		},
+		{
+			desc: "valid: OIDC with organization claims",
+			manifest: []byte(`
+apiVersion: hub.traefik.io/v1alpha1
+kind: APIPortalAuth
+metadata:
+  name: my-auth
+  namespace: default
+spec:
+  oidc:
+    issuerUrl: "https://auth.example.com"
+    secretName: "oidc-secret"
+    claims:
+      groups: "groups"
+      organizationId: "org_id"
+      organizationName: "org_name"`),
+		},
+		{
+			desc: "valid: OIDC with only organizationId claim",
+			manifest: []byte(`
+apiVersion: hub.traefik.io/v1alpha1
+kind: APIPortalAuth
+metadata:
+  name: my-auth
+  namespace: default
+spec:
+  oidc:
+    issuerUrl: "https://auth.example.com"
+    secretName: "oidc-secret"
+    claims:
+      groups: "groups"
+      organizationId: "org_id"`),
+		},
+		{
+			desc: "valid: OIDC with only organizationName claim",
+			manifest: []byte(`
+apiVersion: hub.traefik.io/v1alpha1
+kind: APIPortalAuth
+metadata:
+  name: my-auth
+  namespace: default
+spec:
+  oidc:
+    issuerUrl: "https://auth.example.com"
+    secretName: "oidc-secret"
+    claims:
+      groups: "groups"
+      organizationName: "org_name"`),
 		},
 		{
 			desc: "valid: OIDC with clientConfig",


### PR DESCRIPTION
This PR adds two new optional OIDC claim mappings to the `APIPortalAuth` CRD: `organizationId` and `organizationName`. They let operators map the organization a user belongs to from their JWT claims.

The changes are pretty simple — we've added the two fields to the `Claims` struct, regenerated the CRD manifest accordingly, and updated the validation tests to cover them. Since the two claims are independent, we also added cases proving each can be set on its own without requiring the other.

## How to test this:

Apply an `APIPortalAuth` resource mapping the new claims:

```yaml
apiVersion: hub.traefik.io/v1alpha1
kind: APIPortalAuth
metadata:
  name: my-auth
  namespace: default
spec:
  oidc:
    issuerUrl: "https://auth.example.com"
    secretName: "oidc-secret"
    claims:
      groups: "groups"
      organizationId: "org_id"
      organizationName: "org_name"
```

Or run the validation tests directly:

```bash
go test ./pkg/validation/v1alpha1/ -run TestAPIPortalAuth_Validation
```

## Additional Notes:

The new fields are claim *mappings* only — they're intentionally not part of the `syncedAttributes` enum.
