### PR TITLE
fix: validate Uplink exposeName against rule-injection

### DIFF
--- a/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_uplinks.yaml
+++ b/pkg/apis/hub/v1alpha1/crd/hub.traefik.io_uplinks.yaml
@@ -51,6 +51,8 @@ spec:
                 description: |-
                   ExposeName is the name of the service to expose.
                   By default it uses <namespace>-<name>.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
                 type: string
               healthCheck:
                 description: HealthCheck configures the active health check on the

--- a/pkg/apis/hub/v1alpha1/uplink.go
+++ b/pkg/apis/hub/v1alpha1/uplink.go
@@ -45,6 +45,8 @@ type UplinkSpec struct {
 	// ExposeName is the name of the service to expose.
 	// By default it uses <namespace>-<name>.
 	// +optional
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$`
 	ExposeName string `json:"exposeName,omitempty"`
 
 	// EntryPoints references uplinkEntryPoints. When omitted, uses default uplinkEntrypoints.


### PR DESCRIPTION
### Description

This PR adds validation to `Uplink.spec.exposeName` to close a router-rule injection in the multi-cluster uplink provider. The field was a free-form `string` with no schema constraint, so a tenant could set a value containing backticks, parentheses, `|` or `&` and break out of the generated router rule to hijack cross-tenant traffic.

The `+kubebuilder:validation:Pattern` + `MaxLength` annotations make the API server reject malformed values at admission (fail-closed), before they ever reach the provider. 

Fixes https://github.com/traefik/hub-issues/issues/2893