### PR TITLE
ci: stop persisting github token on actions/checkout

### DIFF
--- a/.github/workflows/lint-on-pr.yaml
+++ b/.github/workflows/lint-on-pr.yaml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go 1.x
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0

--- a/.github/workflows/template-update-crds-go-project.yaml
+++ b/.github/workflows/template-update-crds-go-project.yaml
@@ -18,6 +18,7 @@ jobs:
       - name: checkout target repo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          persist-credentials: false
           repository: ${{ inputs.TARGET_REPO }}
           ref: ${{ inputs.TARGET_BRANCH }}
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/update-crds.yaml
+++ b/.github/workflows/update-crds.yaml
@@ -20,12 +20,14 @@ jobs:
       - name: checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          persist-credentials: false
           repository: traefik/hub-crds
           path: ${{ github.workspace }}/hub-crds
           ref: ${{ env.GIT_TAG }}
       - name: checkout traefik-helm-chart repo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          persist-credentials: false
           repository: traefik/traefik-helm-chart
           ref: master
           token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
### Motivation

Resolve hub-crds's Aikido SAST finding: `actions/checkout` steps persisted the GitHub token in `.git/config`. All checkouts now set `persist-credentials: false` — the update-crds workflows check out other repos with an explicit `token:` and open PRs via `peter-evans/create-pull-request` (its own token), so nothing relies on the persisted credentials.

- actions/checkout persists Git credentials: https://app.aikido.dev/queue?issue_id_filter=33654896
