### PR TITLE
ci: drop copy to removed traefik-crds chart

### DIFF
--- a/.github/workflows/update-crds.yaml
+++ b/.github/workflows/update-crds.yaml
@@ -34,8 +34,6 @@ jobs:
           path: ${{ github.workspace }}/traefik-helm-chart
       - name: copy on Traefik main Chart
         run: rsync -crv --delete --exclude='kustomization.yaml' --exclude='gateway-standard-install.yaml' --exclude='traefik.io_*.yaml' --exclude='*.go' ${{ github.workspace }}/hub-crds/pkg/apis/hub/v1alpha1/crd/ ${{ github.workspace }}/traefik-helm-chart/traefik/crds/
-      - name: copy on optional CRDs Chart
-        run: rsync -crv --delete --exclude='kustomization.yaml' --exclude='gateway-standard-install.yaml' --exclude='traefik.io_*.yaml' --exclude='*.go' ${{ github.workspace }}/hub-crds/pkg/apis/hub/v1alpha1/crd/ ${{ github.workspace }}/traefik-helm-chart/traefik-crds/crds-files/hub/
       - name: create PR
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:


### PR DESCRIPTION
# Motivation

The `traefik-crds` chart was removed from `traefik/traefik-helm-chart` master in `fd6fca3` (chore(crds): remove deprecated traefik-crds chart), so `traefik-crds/crds-files/hub/` no longer exists and the release workflow fails on rsync. Hub CRDs are already synced to `traefik/crds/` by the previous step.

Fixes traefik/hub-issues#2953